### PR TITLE
Restore personality to About page bio

### DIFF
--- a/.changeset/about-personality.md
+++ b/.changeset/about-personality.md
@@ -1,0 +1,5 @@
+---
+"portfolio": minor
+---
+
+Expand About page bio with multi-paragraph narrative and add "Beyond Work" interests section.

--- a/content/home.json
+++ b/content/home.json
@@ -102,5 +102,17 @@
       "Computational Physics"
     ]
   },
-  "about": "Sean Bearden earned his Ph.D. in Physics from UC San Diego as a member of Dr. Massimiliano Di Ventra's research group, focusing on constraint satisfaction problems using digital memcomputing machines. A nontraditional learner who began his academic journey while incarcerated, he went from a GED to a Ph.D. He is committed to lifelong learning, creative projects with Arduino and Raspberry Pi, and practices Brazilian Jiu-Jitsu in San Diego."
+  "about": "Physicist turned data scientist. Ph.D. from UC San Diego in memcomputing — a non-quantum alternative computing paradigm. Now applying that research mindset to financial services, AI assistants, and platform engineering.",
+  "bio": [
+    "I earned my Ph.D. in Physics from UC San Diego under Dr. Massimiliano Di Ventra, designing dynamical-systems algorithms for constraint satisfaction problems. The work was published in Nature Scientific Reports, Communications Physics, and Physical Review Applied, and built an independent memcomputing implementation separate from MemComputing, Inc.",
+    "My path here wasn't linear. I started with a GED while incarcerated, transferred from Ohio University to SUNY Buffalo for a B.S. in Physics and Applied Mathematics, then to UCSD for graduate work. The Story Collider podcast captured part of that story. I've talked about it more openly because the path I took shouldn't be unusual — it should be possible.",
+    "Today I work as a data scientist across two companies under common ownership: Bayview Solutions LLC (debt portfolio management, COGS modeling, BigQuery analytics) and Cash Lane Holdings (consumer lending, LangGraph-powered AI assistants on Google Cloud). I'm also Product Owner for an enterprise platform migration at BV-Tech-Solutions. The work spans ETL pipelines, RAG systems, conversational AI, and forecasting — building things that actually run in production."
+  ],
+  "interests": [
+    "Brazilian Jiu-Jitsu at P5 Academy in San Diego",
+    "Arduino and Raspberry Pi projects (the talking Deadpool head was a personal favorite)",
+    "Buffalo, NY native — and yes, a connoisseur of chicken wings",
+    "Storytelling and public speaking, including a Story Collider appearance",
+    "Lifelong learner — currently into LLM agent architectures and Kaggle competitions"
+  ]
 }

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { buttonVariants } from "@/components/ui/button";
 import { getHomeData, pdfUrl } from "@/utils/content";
-import { Award, Briefcase, GraduationCap, Download } from "lucide-react";
+import { Award, Briefcase, GraduationCap, Download, Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export function AboutPage() {
@@ -12,9 +12,13 @@ export function AboutPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-12">
       <h1 className="text-3xl font-bold tracking-tight">About</h1>
-      <p className="mt-4 text-muted-foreground leading-relaxed">{home.about}</p>
+      <div className="mt-4 space-y-4 text-muted-foreground leading-relaxed">
+        {home.bio.map((paragraph, idx) => (
+          <p key={idx}>{paragraph}</p>
+        ))}
+      </div>
 
-      <div className="mt-4 flex gap-3">
+      <div className="mt-6 flex gap-3">
         <a
           href={pdfUrl("Bearden_Resume_Online.pdf")}
           target="_blank"
@@ -114,6 +118,20 @@ export function AboutPage() {
             </div>
           ))}
         </div>
+      </section>
+
+      <Separator className="my-10" />
+
+      {/* Beyond Work */}
+      <section>
+        <h2 className="flex items-center gap-2 text-2xl font-semibold mb-6">
+          <Heart className="h-5 w-5" /> Beyond Work
+        </h2>
+        <ul className="list-disc pl-5 space-y-2 text-muted-foreground">
+          {home.interests.map((interest) => (
+            <li key={interest}>{interest}</li>
+          ))}
+        </ul>
       </section>
     </div>
   );

--- a/frontend/src/types/content.ts
+++ b/frontend/src/types/content.ts
@@ -54,4 +54,6 @@ export interface HomeData {
   awards: string[];
   skills: Record<string, string[]>;
   about: string;
+  bio: string[];
+  interests: string[];
 }


### PR DESCRIPTION
## Summary
- Expand About page bio from one corporate paragraph to a 3-paragraph narrative covering the GED→PhD academic path, current work, and personal background
- Add new "Beyond Work" section listing personal interests (BJJ, Arduino, Buffalo, Story Collider)
- Tighten the home page \`about\` preview to a sharper one-liner so it doesn't duplicate the long-form bio
- Extends \`HomeData\` type with \`bio: string[]\` and \`interests: string[]\`

The original Squarespace site conveyed a redemption-road narrative and personality details that got compressed into a single paragraph during migration. This restores them.

Closes #4

## Test plan
- [ ] \`npm run dev\` — /about renders 3 bio paragraphs and Beyond Work section
- [ ] / (home) shows the new short \`about\` blurb
- [ ] No type errors
- [ ] Mobile + desktop spacing looks right