### PR TITLE
Add 'Chat with My Resume' CTA to hero

### DIFF
--- a/.changeset/chat-resume-cta.md
+++ b/.changeset/chat-resume-cta.md
@@ -1,0 +1,5 @@
+---
+"portfolio": minor
+---
+
+Add "Chat with My Resume" CTA to home page hero, linking to the existing resume chatbot at bearden-resume-chatbot.com (until Phase 2 ports it to /chat).

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { ArrowRight, Mail } from "lucide-react";
+import { ArrowRight, Mail, MessageSquare } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -30,7 +30,15 @@ export function HomePage() {
               {home.hero.headline}
             </p>
             <div className="mt-8 flex flex-wrap justify-center gap-3 md:justify-start">
-              <Link to="/portfolio" className={cn(buttonVariants())}>
+              <a
+                href="https://bearden-resume-chatbot.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(buttonVariants())}
+              >
+                <MessageSquare className="mr-2 h-4 w-4" /> Chat with My Resume
+              </a>
+              <Link to="/portfolio" className={cn(buttonVariants({ variant: "outline" }))}>
                 View Portfolio
               </Link>
               <a


### PR DESCRIPTION
## Summary
- Adds primary CTA \"Chat with My Resume\" to the home hero
- Targets existing chatbot at https://bearden-resume-chatbot.com
- Promoted to primary button; \"View Portfolio\" demoted to outline variant
- Will be replaced with internal \`/chat\` route when Phase 2 ships

Closes #6

## Test plan
- [ ] CTA visible on desktop and mobile hero
- [ ] Link opens chatbot in new tab
- [ ] Other CTAs (Portfolio, Resume, Contact) still work