### PR TITLE
Add Press & Media section to About page

### DIFF
--- a/.changeset/about-personality.md
+++ b/.changeset/about-personality.md
@@ -1,0 +1,5 @@
+---
+"portfolio": minor
+---
+
+Expand About page bio with multi-paragraph narrative and add "Beyond Work" interests section.

--- a/.changeset/press-section.md
+++ b/.changeset/press-section.md
@@ -1,0 +1,5 @@
+---
+"portfolio": minor
+---
+
+Add Press & Media section to About page surfacing external coverage (Physics Today, Story Collider, Buffalo News, UB Reporter, Ohio Today, The Spectrum).

--- a/content/home.json
+++ b/content/home.json
@@ -102,5 +102,17 @@
       "Computational Physics"
     ]
   },
-  "about": "Sean Bearden earned his Ph.D. in Physics from UC San Diego as a member of Dr. Massimiliano Di Ventra's research group, focusing on constraint satisfaction problems using digital memcomputing machines. A nontraditional learner who began his academic journey while incarcerated, he went from a GED to a Ph.D. He is committed to lifelong learning, creative projects with Arduino and Raspberry Pi, and practices Brazilian Jiu-Jitsu in San Diego."
+  "about": "Physicist turned data scientist. Ph.D. from UC San Diego in memcomputing — a non-quantum alternative computing paradigm. Now applying that research mindset to financial services, AI assistants, and platform engineering.",
+  "bio": [
+    "I earned my Ph.D. in Physics from UC San Diego under Dr. Massimiliano Di Ventra, designing dynamical-systems algorithms for constraint satisfaction problems. The work was published in Nature Scientific Reports, Communications Physics, and Physical Review Applied, and built an independent memcomputing implementation separate from MemComputing, Inc.",
+    "My path here wasn't linear. I started with a GED while incarcerated, transferred from Ohio University to SUNY Buffalo for a B.S. in Physics and Applied Mathematics, then to UCSD for graduate work. The Story Collider podcast captured part of that story. I've talked about it more openly because the path I took shouldn't be unusual — it should be possible.",
+    "Today I work as a data scientist across two companies under common ownership: Bayview Solutions LLC (debt portfolio management, COGS modeling, BigQuery analytics) and Cash Lane Holdings (consumer lending, LangGraph-powered AI assistants on Google Cloud). I'm also Product Owner for an enterprise platform migration at BV-Tech-Solutions. The work spans ETL pipelines, RAG systems, conversational AI, and forecasting — building things that actually run in production."
+  ],
+  "interests": [
+    "Brazilian Jiu-Jitsu at P5 Academy in San Diego",
+    "Arduino and Raspberry Pi projects (the talking Deadpool head was a personal favorite)",
+    "Buffalo, NY native — and yes, a connoisseur of chicken wings",
+    "Storytelling and public speaking, including a Story Collider appearance",
+    "Lifelong learner — currently into LLM agent architectures and Kaggle competitions"
+  ]
 }

--- a/content/home.json
+++ b/content/home.json
@@ -114,5 +114,49 @@
     "Buffalo, NY native — and yes, a connoisseur of chicken wings",
     "Storytelling and public speaking, including a Story Collider appearance",
     "Lifelong learner — currently into LLM agent architectures and Kaggle competitions"
+  ],
+  "press": [
+    {
+      "title": "Q&A: Sean Bearden on his journey from prison to a Ph.D. in physics",
+      "source": "Physics Today",
+      "date": "2020-05",
+      "url": "https://physicstoday.scitation.org/do/10.1063/PT.6.4.20200501a/full/"
+    },
+    {
+      "title": "A Whole New World — Stories About Taking On the Challenge of a Whole New Existence",
+      "source": "The Story Collider",
+      "date": "2020-02",
+      "url": "https://www.storycollider.org/stories/2020/2/18/a-whole-new-world-stories-about-having-to-take-on-the-challenge-of-a-whole-new-existence"
+    },
+    {
+      "title": "Leading through education",
+      "source": "Ohio Today",
+      "date": "2016",
+      "url": "https://ohiotoday.org/spring-2016/leading-through-education/"
+    },
+    {
+      "title": "Sean Bearden's redemption road",
+      "source": "UB Reporter",
+      "date": "2015-06",
+      "url": "https://www.buffalo.edu/fellowships/start/our-scholars.host.html/content/shared/university/news/ub-reporter-articles/stories/2015/06/bearden_nsf_grad_fellowship.detail.html"
+    },
+    {
+      "title": "Prison adds up to physics career for math whiz Sean Bearden",
+      "source": "The Buffalo News",
+      "date": "2015-06",
+      "url": "https://buffalonews.com/2015/06/21/prison-adds-up-to-physics-career-for-math-whiz-sean-bearden/"
+    },
+    {
+      "title": "UB's outstanding seniors receive awards from the College of Arts and Sciences",
+      "source": "The Spectrum",
+      "date": "2015-05",
+      "url": "https://www.ubspectrum.com/article/2015/05/ubs-outstanding-seniors-receive-awards-from-the-college-of-arts-and-sciences"
+    },
+    {
+      "title": "UB students named Goldwater Scholars",
+      "source": "UB News",
+      "date": "2014-03",
+      "url": "https://www.buffalo.edu/fellowships/start/scholars.host.html/content/shared/university/news/news-center-releases/2014/03/048.detail.html"
+    }
   ]
 }

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { buttonVariants } from "@/components/ui/button";
 import { getHomeData, pdfUrl } from "@/utils/content";
-import { Award, Briefcase, GraduationCap, Download } from "lucide-react";
+import { Award, Briefcase, GraduationCap, Download, Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export function AboutPage() {
@@ -12,9 +12,13 @@ export function AboutPage() {
   return (
     <div className="mx-auto max-w-3xl px-4 py-12">
       <h1 className="text-3xl font-bold tracking-tight">About</h1>
-      <p className="mt-4 text-muted-foreground leading-relaxed">{home.about}</p>
+      <div className="mt-4 space-y-4 text-muted-foreground leading-relaxed">
+        {home.bio.map((paragraph, idx) => (
+          <p key={idx}>{paragraph}</p>
+        ))}
+      </div>
 
-      <div className="mt-4 flex gap-3">
+      <div className="mt-6 flex gap-3">
         <a
           href={pdfUrl("Bearden_Resume_Online.pdf")}
           target="_blank"
@@ -114,6 +118,20 @@ export function AboutPage() {
             </div>
           ))}
         </div>
+      </section>
+
+      <Separator className="my-10" />
+
+      {/* Beyond Work */}
+      <section>
+        <h2 className="flex items-center gap-2 text-2xl font-semibold mb-6">
+          <Heart className="h-5 w-5" /> Beyond Work
+        </h2>
+        <ul className="list-disc pl-5 space-y-2 text-muted-foreground">
+          {home.interests.map((interest) => (
+            <li key={interest}>{interest}</li>
+          ))}
+        </ul>
       </section>
     </div>
   );

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { buttonVariants } from "@/components/ui/button";
 import { getHomeData, pdfUrl } from "@/utils/content";
-import { Award, Briefcase, GraduationCap, Download, Heart } from "lucide-react";
+import { Award, Briefcase, GraduationCap, Download, Heart, Newspaper, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export function AboutPage() {
@@ -95,6 +95,35 @@ export function AboutPage() {
         <ul className="list-disc pl-5 space-y-2 text-muted-foreground">
           {home.awards.map((a) => (
             <li key={a}>{a}</li>
+          ))}
+        </ul>
+      </section>
+
+      <Separator className="my-10" />
+
+      {/* Press & Media */}
+      <section>
+        <h2 className="flex items-center gap-2 text-2xl font-semibold mb-6">
+          <Newspaper className="h-5 w-5" /> Press & Media
+        </h2>
+        <ul className="space-y-3">
+          {home.press.map((item) => (
+            <li key={item.url}>
+              <a
+                href={item.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-start justify-between gap-3 rounded-md border p-3 transition-colors hover:bg-muted/50"
+              >
+                <div className="min-w-0">
+                  <p className="font-medium leading-snug">{item.title}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {item.source} &middot; {item.date}
+                  </p>
+                </div>
+                <ExternalLink className="h-4 w-4 shrink-0 mt-1 text-muted-foreground transition-colors group-hover:text-foreground" />
+              </a>
+            </li>
           ))}
         </ul>
       </section>

--- a/frontend/src/types/content.ts
+++ b/frontend/src/types/content.ts
@@ -42,6 +42,13 @@ export interface Education {
   year: string;
 }
 
+export interface PressItem {
+  title: string;
+  source: string;
+  date: string;
+  url: string;
+}
+
 export interface HomeData {
   hero: {
     name: string;
@@ -56,4 +63,5 @@ export interface HomeData {
   about: string;
   bio: string[];
   interests: string[];
+  press: PressItem[];
 }

--- a/frontend/src/types/content.ts
+++ b/frontend/src/types/content.ts
@@ -54,4 +54,6 @@ export interface HomeData {
   awards: string[];
   skills: Record<string, string[]>;
   about: string;
+  bio: string[];
+  interests: string[];
 }


### PR DESCRIPTION
## Summary
- Adds 7-item Press & Media section to About page below Awards
- Surfaces external coverage that was on the old Squarespace site:
  - Physics Today Q&A (May 2020)
  - The Story Collider podcast (Feb 2020)
  - Ohio Today: Leading through education (2016)
  - UB Reporter: Sean Bearden's redemption road (Jun 2015)
  - The Buffalo News: Prison adds up to physics career (Jun 2015)
  - The Spectrum: UB outstanding seniors (May 2015)
  - UB News: Goldwater Scholars (Mar 2014)
- Adds \`PressItem\` type and \`press\` field to \`HomeData\`
- Each press card opens externally in a new tab

> ⚠️ **Stacked on \`feat/about-personality\` (#11).** Built off that branch so \`bio\`/\`interests\` schema is consistent. Once #11 merges, GitHub will show this PR's diff cleanly against main.

Closes #5

## Test plan
- [ ] /about renders Press & Media section between Awards and Skills
- [ ] Each press item opens correct URL in new tab
- [ ] Mobile + desktop layout looks right
- [ ] No type errors