### PR TITLE
Auto-label new issues with 'jules' tag

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,19 @@
+name: Auto-label new issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add jules label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: gh issue edit "$ISSUE" --add-label "jules" --repo "$REPO"


### PR DESCRIPTION
## Summary
- New workflow \`.github/workflows/auto-label-issues.yml\` triggers on issue open
- Adds \`jules\` label to every new issue, routing it to the Jules (Google) coding agent
- Uses built-in \`GITHUB_TOKEN\` with \`issues: write\` permission — no extra secrets

## Test plan
After merge, open a throwaway issue and confirm it auto-tags with \`jules\`. Close the test issue when verified.

## Notes
\`jules\` label already exists in the repo. If we want to scope this (e.g., only certain issue templates get auto-tagged), we can add filters later.