### PR TITLE
🧪 [testing improvement] Add try-catch path test in parseFrontmatter

### DIFF
--- a/frontend/src/utils/content.test.ts
+++ b/frontend/src/utils/content.test.ts
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+// Mock import.meta for content.ts (this needs to be done BEFORE importing content.ts if possible)
+// But we can't easily mock import.meta for a module we are about to import in Node.js ESM without loaders.
+// However, we can try to use a trick if content.ts was using globalThis or if we use a loader.
+// Since we are using node --test, we can try to provide a mock via globalThis if the code was designed for it,
+// but it's using import.meta.env directly.
+
+import { parseFrontmatter } from './content.ts';
+
+test('parseFrontmatter handles valid frontmatter', () => {
+  const input = `---
+title: "Hello World"
+date: 2024-05-20
+slug: hello-world
+---
+This is the body.`;
+
+  const result = parseFrontmatter(input);
+
+  assert.strictEqual(result.meta.title, 'Hello World');
+  assert.strictEqual(result.meta.date, '2024-05-20');
+  assert.strictEqual(result.meta.slug, 'hello-world');
+  assert.strictEqual(result.body, 'This is the body.');
+});
+
+test('parseFrontmatter handles valid JSON array', () => {
+  const input = `---
+tags: ["tag1", "tag2"]
+---
+Body`;
+
+  const result = parseFrontmatter(input);
+
+  assert.deepStrictEqual(result.meta.tags, ['tag1', 'tag2']);
+});
+
+test('parseFrontmatter handles invalid JSON array with fallback', () => {
+  const input = `---
+tags: [invalid, json]
+---
+Body`;
+
+  const result = parseFrontmatter(input);
+
+  // Fallback to string
+  assert.strictEqual(result.meta.tags, '[invalid, json]');
+});
+
+test('parseFrontmatter handles non-array starting with [', () => {
+    const input = `---
+key: [not really a json array
+---
+Body`;
+
+    const result = parseFrontmatter(input);
+
+    assert.strictEqual(result.meta.key, '[not really a json array');
+});
+
+test('parseFrontmatter handles no frontmatter', () => {
+  const input = 'No frontmatter here.';
+  const result = parseFrontmatter(input);
+
+  assert.deepStrictEqual(result.meta, {});
+  assert.strictEqual(result.body, 'No frontmatter here.');
+});

--- a/frontend/src/utils/content.test.ts
+++ b/frontend/src/utils/content.test.ts
@@ -1,13 +1,7 @@
+/// <reference types="node" />
 import test from 'node:test';
 import assert from 'node:assert';
-
-// Mock import.meta for content.ts (this needs to be done BEFORE importing content.ts if possible)
-// But we can't easily mock import.meta for a module we are about to import in Node.js ESM without loaders.
-// However, we can try to use a trick if content.ts was using globalThis or if we use a loader.
-// Since we are using node --test, we can try to provide a mock via globalThis if the code was designed for it,
-// but it's using import.meta.env directly.
-
-import { parseFrontmatter } from './content.ts';
+import { parseFrontmatter } from './parse-frontmatter.ts';
 
 test('parseFrontmatter handles valid frontmatter', () => {
   const input = `---

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -1,6 +1,7 @@
 import type { BlogPost, PortfolioProject, Publication, HomeData } from "@/types/content";
+import { parseFrontmatter } from "./parse-frontmatter";
 
-const ASSETS_BASE = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_ASSETS_BASE_URL : "";
+const ASSETS_BASE = import.meta.env.VITE_ASSETS_BASE_URL ?? "";
 
 export function assetUrl(filename: string): string {
   if (!filename) return "";
@@ -19,37 +20,12 @@ interface RawMarkdown {
   frontmatter: Record<string, unknown>;
 }
 
-const blogModules = typeof import.meta.glob !== 'undefined' ? import.meta.glob<RawMarkdown>("../../../content/blog/*.md", {
+const blogModules = import.meta.glob<RawMarkdown>("../../../content/blog/*.md", {
   eager: true,
   query: "?raw",
   import: "default",
-}) : {};
+});
 
-export function parseFrontmatter(raw: string): { meta: Record<string, string | string[]>; body: string } {
-  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-  if (!match) return { meta: {}, body: raw };
-
-  const meta: Record<string, string | string[]> = {};
-  for (const line of match[1].split("\n")) {
-    const idx = line.indexOf(":");
-    if (idx === -1) continue;
-    const key = line.slice(0, idx).trim();
-    let val = line.slice(idx + 1).trim();
-    // Remove surrounding quotes
-    if (val.startsWith('"') && val.endsWith('"')) {
-      val = val.slice(1, -1);
-    }
-    // Parse JSON arrays
-    if (val.startsWith("[")) {
-      try {
-        meta[key] = JSON.parse(val);
-        continue;
-      } catch { /* fall through */ }
-    }
-    meta[key] = val;
-  }
-  return { meta, body: match[2].trim() };
-}
 
 let _blogPosts: BlogPost[] | null = null;
 
@@ -83,11 +59,11 @@ export function getBlogPost(slug: string): BlogPost | undefined {
 
 // --- Portfolio projects ---
 
-const portfolioModules = typeof import.meta.glob !== 'undefined' ? import.meta.glob<string>("../../../content/portfolio/*.md", {
+const portfolioModules = import.meta.glob<string>("../../../content/portfolio/*.md", {
   eager: true,
   query: "?raw",
   import: "default",
-}) : {};
+});
 
 let _projects: PortfolioProject[] | null = null;
 
@@ -117,7 +93,7 @@ export function getProjects(): PortfolioProject[] {
 
 // --- Publications ---
 
-import publicationsJson from "../../../content/publications.json" with { type: "json" };
+import publicationsJson from "../../../content/publications.json";
 
 export function getPublications(): Publication[] {
   return publicationsJson as Publication[];
@@ -125,7 +101,7 @@ export function getPublications(): Publication[] {
 
 // --- Home data ---
 
-import homeJson from "../../../content/home.json" with { type: "json" };
+import homeJson from "../../../content/home.json";
 
 export function getHomeData(): HomeData {
   return homeJson as HomeData;

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -1,6 +1,6 @@
 import type { BlogPost, PortfolioProject, Publication, HomeData } from "@/types/content";
 
-const ASSETS_BASE = import.meta.env.VITE_ASSETS_BASE_URL ?? "";
+const ASSETS_BASE = typeof import.meta.env !== 'undefined' ? import.meta.env.VITE_ASSETS_BASE_URL : "";
 
 export function assetUrl(filename: string): string {
   if (!filename) return "";
@@ -19,13 +19,13 @@ interface RawMarkdown {
   frontmatter: Record<string, unknown>;
 }
 
-const blogModules = import.meta.glob<RawMarkdown>("../../../content/blog/*.md", {
+const blogModules = typeof import.meta.glob !== 'undefined' ? import.meta.glob<RawMarkdown>("../../../content/blog/*.md", {
   eager: true,
   query: "?raw",
   import: "default",
-});
+}) : {};
 
-function parseFrontmatter(raw: string): { meta: Record<string, string | string[]>; body: string } {
+export function parseFrontmatter(raw: string): { meta: Record<string, string | string[]>; body: string } {
   const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) return { meta: {}, body: raw };
 
@@ -83,11 +83,11 @@ export function getBlogPost(slug: string): BlogPost | undefined {
 
 // --- Portfolio projects ---
 
-const portfolioModules = import.meta.glob<string>("../../../content/portfolio/*.md", {
+const portfolioModules = typeof import.meta.glob !== 'undefined' ? import.meta.glob<string>("../../../content/portfolio/*.md", {
   eager: true,
   query: "?raw",
   import: "default",
-});
+}) : {};
 
 let _projects: PortfolioProject[] | null = null;
 
@@ -117,7 +117,7 @@ export function getProjects(): PortfolioProject[] {
 
 // --- Publications ---
 
-import publicationsJson from "../../../content/publications.json";
+import publicationsJson from "../../../content/publications.json" with { type: "json" };
 
 export function getPublications(): Publication[] {
   return publicationsJson as Publication[];
@@ -125,7 +125,7 @@ export function getPublications(): Publication[] {
 
 // --- Home data ---
 
-import homeJson from "../../../content/home.json";
+import homeJson from "../../../content/home.json" with { type: "json" };
 
 export function getHomeData(): HomeData {
   return homeJson as HomeData;

--- a/frontend/src/utils/parse-frontmatter.ts
+++ b/frontend/src/utils/parse-frontmatter.ts
@@ -1,0 +1,25 @@
+export function parseFrontmatter(raw: string): { meta: Record<string, string | string[]>; body: string } {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { meta: {}, body: raw };
+
+  const meta: Record<string, string | string[]> = {};
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    let val = line.slice(idx + 1).trim();
+    // Remove surrounding quotes
+    if (val.startsWith('"') && val.endsWith('"')) {
+      val = val.slice(1, -1);
+    }
+    // Parse JSON arrays
+    if (val.startsWith("[")) {
+      try {
+        meta[key] = JSON.parse(val);
+        continue;
+      } catch { /* fall through */ }
+    }
+    meta[key] = val;
+  }
+  return { meta, body: match[2].trim() };
+}


### PR DESCRIPTION
🎯 **What:** Added unit tests for `parseFrontmatter` in `frontend/src/utils/content.ts`.
📊 **Coverage:**
- Standard frontmatter parsing.
- Valid JSON array parsing in frontmatter.
- Invalid JSON array parsing with fallback to string (testing the `try-catch` block).
- Inputs without frontmatter.
✨ **Result:** Improved reliability of the content parsing logic and ensured that the fallback mechanism for invalid frontmatter JSON is correctly functioning and verified. The utility is also now compatible with standard Node.js for easier testing.

---
*PR created automatically by Jules for task [16240501167062420866](https://jules.google.com/task/16240501167062420866) started by @seanbearden*