### PR TITLE
🧹 [code health] remove redundant ternary operator for project link

### DIFF
--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -41,7 +41,7 @@ export function PortfolioPage() {
               </div>
               {project.link && (
                 <a
-                  href={project.link.startsWith("/") ? project.link : project.link}
+                  href={project.link}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="mt-3 inline-flex items-center gap-1 text-sm font-medium hover:underline"


### PR DESCRIPTION
🎯 **What:** Removed redundant `href={project.link.startsWith("/") ? project.link : project.link}` in `PortfolioPage.tsx`
💡 **Why:** The ternary operator returned `project.link` in both branches, making it entirely redundant. Simplifying to `href={project.link}` improves code readability.
✅ **Verification:** Ran format, lint, and build. Build succeeds. Changes look correct in `git diff`.
✨ **Result:** Cleaner code in `PortfolioPage.tsx`.

---
*PR created automatically by Jules for task [9058178735905210381](https://jules.google.com/task/9058178735905210381) started by @seanbearden*