### PR TITLE
🧹 [Code Health] Fix type for import.meta.glob in content.ts

### DIFF
--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -14,12 +14,7 @@ export function pdfUrl(filename: string): string {
 
 // --- Blog posts ---
 
-interface RawMarkdown {
-  default: string;
-  frontmatter: Record<string, unknown>;
-}
-
-const blogModules = import.meta.glob<RawMarkdown>("../../../content/blog/*.md", {
+const blogModules = import.meta.glob<string>("../../../content/blog/*.md", {
   eager: true,
   query: "?raw",
   import: "default",


### PR DESCRIPTION
🎯 **What:** Changed `import.meta.glob<RawMarkdown>` to `import.meta.glob<string>` for `blogModules` and removed unused `RawMarkdown` interface.

💡 **Why:** `import.meta.glob` with `?raw` and `import: 'default'` returns raw strings, not module objects. The old `RawMarkdown` interface was unused and incorrect. This caused the `typeof raw === "string"` check to appear incorrect based on the type definition.

✅ **Verification:**
- Validated via `npm run build` in `frontend/`
- Validated via `npm run lint` in `frontend/`

✨ **Result:** Accurate type definition reflecting the runtime values.

---
*PR created automatically by Jules for task [3400149956421198377](https://jules.google.com/task/3400149956421198377) started by @seanbearden*