### PR TITLE
Improve Featured Project Cards on Home Page

### DIFF
--- a/content/portfolio/01-resume-chatbot-harnessing-chatgpt-for-the-job-sear.md
+++ b/content/portfolio/01-resume-chatbot-harnessing-chatgpt-for-the-job-sear.md
@@ -1,9 +1,11 @@
 ---
-title: "Resume Chatbot: Harnessing ChatGPT for the Job Search"
+title: "Resume Chatbot"
+subtitle: "Harnessing ChatGPT for the job search"
 slug: resume-chatbot-harnessing-chatgpt-for-the-job-search
 order: 1
 skills: ["Python", "LangChain", "LLM (ChatGPT)", "AWS SAM", "DynamoDB", "Heroku", "Dashboards"]
 link: "https://bearden-resume-chatbot.com"
+cta: "Chat with My Resume"
 image: lp_logo_3.0.webp
 ---
 

--- a/content/portfolio/03-understanding-my-phd-research-the-search-for-king-.md
+++ b/content/portfolio/03-understanding-my-phd-research-the-search-for-king-.md
@@ -1,9 +1,11 @@
 ---
-title: "Understanding My PhD Research - The Search For King Turing's Stolen Treasure"
+title: "PhD Research"
+subtitle: "The Search For King Turing's Stolen Treasure"
 slug: understanding-my-phd-research-the-search-for-king-turings-stolen-treasure
 order: 3
 skills: ["Keynote", "Non-Technical Presentation", "Graphic Design"]
 link: "https://youtu.be/wvPlTin-Nto"
+cta: "Watch The Video"
 ---
 
 Non-technical video presentation making complex doctoral research accessible. Uses storytelling metaphor to explain concepts spanning computational complexity, statistical mechanics, computer science, and theoretical mathematics.

--- a/content/portfolio/04-publication-efficient-solution-of-boolean-satisfia.md
+++ b/content/portfolio/04-publication-efficient-solution-of-boolean-satisfia.md
@@ -1,9 +1,11 @@
 ---
-title: "Publication: Efficient Solution of Boolean Satisfiability Problems with Digital Memcomputing"
+title: "SAT Publication"
+subtitle: "Efficient Solution of Boolean Satisfiability Problems with Digital Memcomputing"
 slug: publication-efficient-solution-of-boolean-satisfiability-problems-with-digital-memcomputing
 order: 4
 skills: ["MATLAB", "Dynamical System Design", "Technical Writing", "Graphic Design"]
 link: "https://www.nature.com/articles/s41598-020-76666-2"
+cta: "Read The Publication"
 ---
 
 Peer-reviewed research on memory-assisted physical systems (digital memcomputing machines) solving Boolean satisfiability problems. Shows evidence for polynomially-bounded scalability while solving 'hard' planted-solution instances of SAT.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/geist": "^5.2.8",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -59,9 +59,9 @@ export function HomePage() {
         </div>
         <div className="grid gap-6 md:grid-cols-3">
           {projects.map((project) => (
-            <Card key={project.slug} className="overflow-hidden">
+            <Card key={project.slug} className="overflow-hidden flex flex-col">
               {project.image && (
-                <div className="aspect-video bg-muted">
+                <div className="aspect-video bg-muted shrink-0">
                   <img
                     src={assetUrl(project.image)}
                     alt={project.title}
@@ -70,15 +70,32 @@ export function HomePage() {
                   />
                 </div>
               )}
-              <CardContent className="p-4">
-                <h3 className="font-medium leading-snug">{project.title}</h3>
-                <div className="mt-2 flex flex-wrap gap-1">
-                  {project.skills.slice(0, 3).map((skill) => (
-                    <Badge key={skill} variant="secondary" className="text-xs">
+              <CardContent className="p-4 flex flex-col flex-grow">
+                <h3 className="font-semibold leading-snug">{project.title}</h3>
+                {project.subtitle && (
+                  <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
+                    {project.subtitle}
+                  </p>
+                )}
+                <div className="mt-3 flex flex-wrap gap-1">
+                  {project.skills.map((skill) => (
+                    <Badge key={skill} variant="secondary" className="text-[10px] px-1.5 py-0">
                       {skill}
                     </Badge>
                   ))}
                 </div>
+                {project.link && project.cta && (
+                  <div className="mt-auto pt-4">
+                    <a
+                      href={project.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sm font-medium text-primary hover:underline flex items-center gap-1"
+                    >
+                      {project.cta} <ArrowRight className="h-3 w-3" />
+                    </a>
+                  </div>
+                )}
               </CardContent>
             </Card>
           ))}

--- a/frontend/src/types/content.ts
+++ b/frontend/src/types/content.ts
@@ -11,10 +11,12 @@ export interface BlogPost {
 
 export interface PortfolioProject {
   title: string;
+  subtitle?: string;
   slug: string;
   order: number;
   skills: string[];
   link?: string;
+  cta?: string;
   relatedPublication?: string;
   image?: string;
   body: string;

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -100,10 +100,12 @@ export function getProjects(): PortfolioProject[] {
     const { meta, body } = parseFrontmatter(content);
     projects.push({
       title: (meta.title as string) ?? "",
+      subtitle: meta.subtitle as string | undefined,
       slug: (meta.slug as string) ?? "",
       order: Number(meta.order) || 0,
       skills: (meta.skills as string[]) ?? [],
       link: meta.link as string | undefined,
+      cta: meta.cta as string | undefined,
       relatedPublication: meta.relatedPublication as string | undefined,
       image: meta.image as string | undefined,
       body,


### PR DESCRIPTION
The featured project cards on the home page were previously limited to just an image, title, and three skill badges. This change enhances them to match the richer Squarespace version by adding:

1.  **Subtitles:** A one-line value proposition for each project.
2.  **Expanded Skills:** All skill badges are now displayed (previously capped at 3).
3.  **Call-to-Action (CTA) Links:** Specific actions like "Chat with My Resume" or "Watch The Video" are now clearly visible and pinned to the bottom of each card.

The implementation involved updating the portfolio markdown frontmatter schema, the TypeScript types, the data parser, and the `HomePage` component's layout to handle these new fields while maintaining a consistent card height.

Fixes #8

---
*PR created automatically by Jules for task [14236819333743436556](https://jules.google.com/task/14236819333743436556) started by @seanbearden*