### PR TITLE
🧪 Refactor and test parseFrontmatter empty input edge cases

### DIFF
--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -1,4 +1,5 @@
 import type { BlogPost, PortfolioProject, Publication, HomeData } from "@/types/content";
+import { parseFrontmatter } from "./parseFrontmatter.ts";
 
 const ASSETS_BASE = import.meta.env.VITE_ASSETS_BASE_URL ?? "";
 
@@ -24,32 +25,6 @@ const blogModules = import.meta.glob<RawMarkdown>("../../../content/blog/*.md", 
   query: "?raw",
   import: "default",
 });
-
-function parseFrontmatter(raw: string): { meta: Record<string, string | string[]>; body: string } {
-  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-  if (!match) return { meta: {}, body: raw };
-
-  const meta: Record<string, string | string[]> = {};
-  for (const line of match[1].split("\n")) {
-    const idx = line.indexOf(":");
-    if (idx === -1) continue;
-    const key = line.slice(0, idx).trim();
-    let val = line.slice(idx + 1).trim();
-    // Remove surrounding quotes
-    if (val.startsWith('"') && val.endsWith('"')) {
-      val = val.slice(1, -1);
-    }
-    // Parse JSON arrays
-    if (val.startsWith("[")) {
-      try {
-        meta[key] = JSON.parse(val);
-        continue;
-      } catch { /* fall through */ }
-    }
-    meta[key] = val;
-  }
-  return { meta, body: match[2].trim() };
-}
 
 let _blogPosts: BlogPost[] | null = null;
 

--- a/frontend/src/utils/parseFrontmatter.test.ts
+++ b/frontend/src/utils/parseFrontmatter.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert";
+import { parseFrontmatter } from "./parseFrontmatter.ts";
+
+test("parseFrontmatter: empty input edge cases", () => {
+  // Test completely empty string
+  assert.deepStrictEqual(parseFrontmatter(""), {
+    meta: {},
+    body: "",
+  });
+
+  // Test string with no frontmatter
+  assert.deepStrictEqual(parseFrontmatter("Just some content"), {
+    meta: {},
+    body: "Just some content",
+  });
+
+  // Test string with empty frontmatter
+  assert.deepStrictEqual(parseFrontmatter("---\n\n---\nbody content"), {
+    meta: {},
+    body: "body content",
+  });
+
+  // Test string with single empty frontmatter delimiter (should treat as body)
+  assert.deepStrictEqual(parseFrontmatter("---\nbody content"), {
+    meta: {},
+    body: "---\nbody content",
+  });
+});
+
+test("parseFrontmatter: valid frontmatter edge cases", () => {
+  // Test valid frontmatter with extra spaces
+  assert.deepStrictEqual(parseFrontmatter("---\n  title  :  My Title  \n---\nbody"), {
+    meta: { title: "My Title" },
+    body: "body",
+  });
+
+  // Test valid frontmatter with JSON arrays
+  assert.deepStrictEqual(parseFrontmatter("---\ntags: [\"a\", \"b\"]\n---\nbody"), {
+    meta: { tags: ["a", "b"] },
+    body: "body",
+  });
+
+  // Test valid frontmatter with quotes
+  assert.deepStrictEqual(parseFrontmatter("---\ntitle: \"Quoted Title\"\n---\nbody"), {
+    meta: { title: "Quoted Title" },
+    body: "body",
+  });
+});

--- a/frontend/src/utils/parseFrontmatter.ts
+++ b/frontend/src/utils/parseFrontmatter.ts
@@ -1,0 +1,25 @@
+export function parseFrontmatter(raw: string): { meta: Record<string, string | string[]>; body: string } {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { meta: {}, body: raw };
+
+  const meta: Record<string, string | string[]> = {};
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    let val = line.slice(idx + 1).trim();
+    // Remove surrounding quotes
+    if (val.startsWith('"') && val.endsWith('"')) {
+      val = val.slice(1, -1);
+    }
+    // Parse JSON arrays
+    if (val.startsWith("[")) {
+      try {
+        meta[key] = JSON.parse(val);
+        continue;
+      } catch { /* fall through */ }
+    }
+    meta[key] = val;
+  }
+  return { meta, body: match[2].trim() };
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "node"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
🎯 **What:** Addressed the testing gap for `parseFrontmatter` by extracting its logic from `content.ts` into a pure utility `parseFrontmatter.ts`. This circumvents testing issues associated with Vite macros (`import.meta.env` / `import.meta.glob`).
📊 **Coverage:** Added test coverage natively using `node:test` for numerous edge cases, including fully empty inputs (`""`), strings completely lacking frontmatter blocks, strings with structurally sound but empty frontmatter, and typical valid markdown frontmatter setups.
✨ **Result:** Substantially improved test reliability and validation for markdown content parsing in the application without introducing regressions or unsafe workarounds into production code.

---
*PR created automatically by Jules for task [9298508045447348938](https://jules.google.com/task/9298508045447348938) started by @seanbearden*