### PR TITLE
chore: backfill changesets for recently merged PRs

### DIFF
--- a/.changeset/cv-download.md
+++ b/.changeset/cv-download.md
@@ -1,0 +1,5 @@
+---
+"portfolio": minor
+---
+
+Add a CV download link separate from the Resume on the home and About pages, sourcing `Bearden_CV.pdf` from the assets bucket.

--- a/.changeset/dynamic-social-links.md
+++ b/.changeset/dynamic-social-links.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Use dynamic social links and email from `home.json` in the site Header and Footer instead of hardcoded values, so contact info stays in sync with the home page.

--- a/.changeset/featured-project-cards.md
+++ b/.changeset/featured-project-cards.md
@@ -1,0 +1,5 @@
+---
+"portfolio": minor
+---
+
+Improve Featured Project cards on the home page with richer summaries and surface them through new `PortfolioProject` fields.

--- a/.changeset/import-meta-glob-type.md
+++ b/.changeset/import-meta-glob-type.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Fix `import.meta.glob` typing in `content.ts` so the eager raw-content map is properly typed without manual assertions.

--- a/.changeset/parsefrontmatter-tests.md
+++ b/.changeset/parsefrontmatter-tests.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Extract `parseFrontmatter` to its own module and add tests covering empty-input edge cases. Adds `vitest`/`jsdom` dev tooling.

--- a/.changeset/portfolio-link-ternary.md
+++ b/.changeset/portfolio-link-ternary.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Remove redundant ternary in `PortfolioPage` project link rendering.

--- a/.changeset/redirects-map-lookup.md
+++ b/.changeset/redirects-map-lookup.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Optimize old-Squarespace URL redirect resolution to use a `Map` lookup instead of array iteration, reducing per-navigation overhead on 404s.

--- a/.changeset/resolve-old-url-tests.md
+++ b/.changeset/resolve-old-url-tests.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Add tests for `resolveOldUrl` covering Squarespace path normalization and unknown-slug fallback.


### PR DESCRIPTION
## Summary

Backfills changesets for merged PRs that landed without one, so they show up in the next release notes (currently bundled into the open `release: version packages` PR #10 → portfolio@0.3.0).

### Included (8 changesets)

| PR | Bump | Note |
|----|------|------|
| #15 | patch | Dynamic social links/email in Header & Footer |
| #17 | patch | Optimize redirect resolution with Map lookup |
| #18 | patch | Remove redundant ternary in PortfolioPage |
| #20 | patch | Fix `import.meta.glob` typing in `content.ts` |
| #28 | minor | Improved Featured Project cards on home page |
| #29 | minor | CV download separate from Resume |
| #30 | patch | Extract & test `parseFrontmatter` edge cases |
| #33 | patch | Tests for `resolveOldUrl` |

### Skipped (intentionally — no shipped change)

- #14 `auto-label-issues.yml` — CI workflow only
- #22 `scripts/convert_content.py` — build-time content tool, not in runtime bundle

## Test plan

- [ ] After merging, confirm PR #10 (`release: version packages`) auto-updates and now includes the 8 entries above
- [ ] Bump remains `0.3.0` (driven by the existing minor changesets) — minors here don't compound

🤖 Generated with [Claude Code](https://claude.com/claude-code)