### PR TITLE
ci: run vitest on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,5 @@ jobs:
 
       - run: npm ci
       - run: npx tsc -b
+      - run: npm test
       - run: npm run build

--- a/frontend/src/utils/parseFrontmatter.test.ts
+++ b/frontend/src/utils/parseFrontmatter.test.ts
@@ -1,49 +1,50 @@
-import test from "node:test";
-import assert from "node:assert";
-import { parseFrontmatter } from "./parseFrontmatter.ts";
+import { describe, it, expect } from "vitest";
+import { parseFrontmatter } from "./parseFrontmatter";
 
-test("parseFrontmatter: empty input edge cases", () => {
-  // Test completely empty string
-  assert.deepStrictEqual(parseFrontmatter(""), {
-    meta: {},
-    body: "",
+describe("parseFrontmatter", () => {
+  it("handles empty input edge cases", () => {
+    expect(parseFrontmatter("")).toEqual({
+      meta: {},
+      body: "",
+    });
+
+    expect(parseFrontmatter("Just some content")).toEqual({
+      meta: {},
+      body: "Just some content",
+    });
+
+    expect(parseFrontmatter("---\n\n---\nbody content")).toEqual({
+      meta: {},
+      body: "body content",
+    });
+
+    expect(parseFrontmatter("---\nbody content")).toEqual({
+      meta: {},
+      body: "---\nbody content",
+    });
   });
 
-  // Test string with no frontmatter
-  assert.deepStrictEqual(parseFrontmatter("Just some content"), {
-    meta: {},
-    body: "Just some content",
+  it("handles valid frontmatter edge cases", () => {
+    expect(parseFrontmatter("---\n  title  :  My Title  \n---\nbody")).toEqual({
+      meta: { title: "My Title" },
+      body: "body",
+    });
+
+    expect(parseFrontmatter("---\ntags: [\"a\", \"b\"]\n---\nbody")).toEqual({
+      meta: { tags: ["a", "b"] },
+      body: "body",
+    });
+
+    expect(parseFrontmatter("---\ntitle: \"Quoted Title\"\n---\nbody")).toEqual({
+      meta: { title: "Quoted Title" },
+      body: "body",
+    });
   });
 
-  // Test string with empty frontmatter
-  assert.deepStrictEqual(parseFrontmatter("---\n\n---\nbody content"), {
-    meta: {},
-    body: "body content",
-  });
-
-  // Test string with single empty frontmatter delimiter (should treat as body)
-  assert.deepStrictEqual(parseFrontmatter("---\nbody content"), {
-    meta: {},
-    body: "---\nbody content",
-  });
-});
-
-test("parseFrontmatter: valid frontmatter edge cases", () => {
-  // Test valid frontmatter with extra spaces
-  assert.deepStrictEqual(parseFrontmatter("---\n  title  :  My Title  \n---\nbody"), {
-    meta: { title: "My Title" },
-    body: "body",
-  });
-
-  // Test valid frontmatter with JSON arrays
-  assert.deepStrictEqual(parseFrontmatter("---\ntags: [\"a\", \"b\"]\n---\nbody"), {
-    meta: { tags: ["a", "b"] },
-    body: "body",
-  });
-
-  // Test valid frontmatter with quotes
-  assert.deepStrictEqual(parseFrontmatter("---\ntitle: \"Quoted Title\"\n---\nbody"), {
-    meta: { title: "Quoted Title" },
-    body: "body",
+  it("falls back to raw string when JSON array is malformed", () => {
+    expect(parseFrontmatter("---\ntags: [not valid json\n---\nbody")).toEqual({
+      meta: { tags: "[not valid json" },
+      body: "body",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Wires \`vitest\` into the existing CI workflow so PRs that break tests get caught before merge. Until now, CI only ran \`tsc -b\` and \`vite build\`; tests were a no-op gate.

## Changes

1. **`.github/workflows/ci.yml`** — adds \`npm test\` between \`tsc -b\` and \`npm run build\`.
2. **\`frontend/src/utils/parseFrontmatter.test.ts\`** — converted from \`node:test\` to \`vitest\` syntax, matching \`redirects.test.ts\`. The \`node:test\` file emitted a \"No test suite found\" warning when vitest tried to discover it. Added one test for the malformed-JSON-array fallback path so the safeJsonParse refactor (#31) has a regression guard.

## Why convert vs. dual-runner

\`vitest\` is already installed (#33) and \`package.json\` declares \`\"test\": \"vitest run\"\`. The \`node:test\` file from #30 was the lone outlier. Converting one file is simpler than supporting two test runners in CI.

## Local verification

\`\`\`
$ cd frontend
$ npx tsc -b   # passes
$ npm test     # 8 tests passed (parseFrontmatter: 3, redirects: 5)
$ npm run build  # passes
\`\`\`

## No changeset

CI / test-config only. Per the convention in #36 (\`AGENTS.md\`), this skips the changeset rule.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, observe \`npm test\` running on subsequent PRs
- [ ] Open a follow-up PR that intentionally breaks a test → CI should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)