### PR TITLE
ci: gate Cloud Run deploys behind 'production' GitHub environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ jobs:
   deploy:
     name: Deploy to Cloud Run
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
     permissions:
       contents: read
       id-token: write
@@ -57,6 +60,7 @@ jobs:
           docker push ${{ env.GAR_REPO }}/frontend:latest
 
       - name: Deploy to Cloud Run
+        id: deploy
         uses: google-github-actions/deploy-cloudrun@v3
         with:
           service: portfolio-frontend
@@ -66,6 +70,5 @@ jobs:
       - name: Deployment summary
         run: |
           echo "## Deployment Complete" >> "$GITHUB_STEP_SUMMARY"
-          URL=$(gcloud run services describe portfolio-frontend --region=us-central1 --format='value(status.url)')
-          echo "- **URL**: $URL" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **URL**: ${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Version**: \`${{ steps.version.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Wires the deploy workflow into a GitHub Environment named `production`. Deploys still trigger on `v*` tag pushes (or manual `workflow_dispatch`), but now they're tracked under repo Settings → Environments with proper history, an environment URL, and a tag-only protection rule.

## What was set up

**Server-side** (already applied via the GitHub API, no code in this PR):
- Created environment `production` (id `14850011202`)
- Branch policy: `protected_branches: false`, `custom_branch_policies: true`
- Custom policy: only refs matching `v*` (type=tag) can deploy to this environment

**In this PR** (`deploy.yml`):
- Adds \`environment: { name: production, url: ${{ steps.deploy.outputs.url }} }\` to the deploy job
- Adds \`id: deploy\` to the Cloud Run deploy step so its \`url\` output can be referenced
- Replaces the manual \`gcloud run services describe ... --format='value(status.url)'\` call in the summary step with the same step output (removes one extra gcloud call per deploy)

## Why an environment for a single-env project

Even with only one environment today:

- **Deploy history & rollback UI**: GitHub's Deployments tab now shows every release with the live URL, version tag, and a re-run button
- **Defense-in-depth on \`workflow_dispatch\`**: the existing trigger already restricts pushes to \`v*\` tags, but \`workflow_dispatch\` accepts any \`ref\` input. The tag-only environment policy stops a misfired dispatch from \`main\` or a feature branch from reaching prod
- **Future-proofing**: when phase 2 (chatbot) lands, \`staging\` becomes a one-line addition with its own env-scoped vars

No required reviewers — the rolling \`release: version packages\` PR (#10) is the human gate. We can layer on an approval rule later if accidents happen.

## What's NOT in this PR

- Repo-level vars (\`GCP_PROJECT_ID\`, \`WIF_POOL\`, etc.) stay where they are. They don't need to be env-scoped until there's a second env to differentiate.
- Terraform doesn't manage the GH environment yet. Could add the \`integrations/github\` provider in a follow-up if we want this to be reproducible from code.

## Test plan

- [ ] CI green on this PR (deploy.yml is not exercised by CI — only on tag push)
- [ ] After merge: next \`v*\` tag push (when PR #10 merges to release v0.3.0) deploys via the new environment
- [ ] Deployment shows up at https://github.com/seanbearden/portfolio/deployments with the Cloud Run URL
- [ ] Try \`gh workflow run deploy --field ref=main\` → should fail with branch-policy violation (verifies tag-only restriction works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)