### PR TITLE
chore: baseline security & quality scaffolding (LICENSE, SECURITY, Dependabot, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Something is broken on the deployed site or in the codebase
+labels: ["bug"]
+body:
+  - type: input
+    id: where
+    attributes:
+      label: Where did this happen?
+      description: URL, page, component, or file path
+      placeholder: e.g. https://seanbearden.com/blog/some-post
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including steps to reproduce
+      placeholder: |
+        1. Open the page
+        2. Click X
+        3. See Y
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: false
+
+  - type: input
+    id: env
+    attributes:
+      label: Browser / OS
+      placeholder: e.g. Firefox 137 on macOS
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/seanbearden/portfolio/security/advisories/new
+    about: Please report security issues privately, not as a public issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an improvement to the site or codebase
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        update-types: ["minor", "patch"]
+    labels:
+      - "dependencies"
+      - "ci"
+
+  - package-ecosystem: "terraform"
+    directory: "/infrastructure"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "infra"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- 1-3 bullets on what changed and why -->
+
+## Changeset
+
+<!-- Per AGENTS.md, every PR that ships code needs a changeset.
+Run `cd frontend && npx changeset` and commit the generated file.
+Skip rules: workflows-only, infra-only, scripts-only, docs-only changes don't need one. -->
+
+- [ ] Added `.changeset/*.md`, OR
+- [ ] N/A — change is workflows / infra / scripts / docs only
+
+## Test plan
+
+<!-- How was this verified? Build pass? Tests added? UI checked in browser? -->
+
+- [ ] `cd frontend && npm run build` passes
+- [ ] `cd frontend && npm test` passes (or N/A)
+- [ ] Manually verified in browser (or N/A)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2026 Sean Bearden
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Note: The MIT License covers code only. Written content (blog posts, portfolio
+descriptions, publications), images, and personal information in this
+repository are not licensed for reuse and remain © Sean Bearden, all rights
+reserved.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you find a security issue in this repository or the deployed site, please report it privately rather than opening a public issue.
+
+**Preferred:** use [GitHub's private vulnerability reporting](https://github.com/seanbearden/portfolio/security/advisories/new) — this opens a private channel between you and the maintainer.
+
+**Alternative:** email `seanbearden@seanbearden.com`.
+
+You can expect:
+
+- Acknowledgement within 7 days
+- A resolution or mitigation plan within 30 days for confirmed issues
+- Public disclosure coordinated with you after a fix ships
+
+## Scope
+
+This policy covers:
+
+- The site at https://seanbearden.com (and the underlying Cloud Run service)
+- Code in this repository (`frontend/`, `infrastructure/`, `scripts/`, GitHub Actions workflows)
+
+Out of scope: third-party services this site links to (LinkedIn, GitHub, etc.) — please report those to the respective providers.
+
+## Supported versions
+
+Only the latest tagged release is supported. The site auto-deploys from `v*` tags on `main`; older versions are not maintained.


### PR DESCRIPTION
## Summary

Phase 2 of the security/quality setup. Phase 1 (server-side API toggles) was applied directly in the same session — see "Already enabled" below.

## Files added (this PR)

| File | Purpose |
|------|---------|
| \`LICENSE\` | MIT license for code, with explicit carve-out reserving rights to written content/images/personal info |
| \`SECURITY.md\` | Enables GitHub's "Report a vulnerability" button + documents response SLA |
| \`.github/dependabot.yml\` | Weekly grouped npm + actions; monthly terraform + docker. Grouping prevents PR-flood. |
| \`.github/pull_request_template.md\` | Reminds contributors to add a changeset — addresses the root cause behind the #34 backfill |
| \`.github/ISSUE_TEMPLATE/bug_report.yml\` | Structured bug template |
| \`.github/ISSUE_TEMPLATE/feature_request.yml\` | Structured feature template |
| \`.github/ISSUE_TEMPLATE/config.yml\` | Disables blank issues; routes security reports to private advisory |

## Already enabled (server-side, no code in this PR)

These were toggled via the GitHub REST API:

- ✅ Dependabot alerts
- ✅ Dependabot security updates (auto-PRs for known vulnerabilities)
- ✅ Private vulnerability reporting
- ✅ CodeQL default setup (JavaScript/TypeScript + Actions). First scan run was triggered as run \`25261054081\`.
- (Already on before this session: secret scanning, push protection, ruleset \`protect-main\`)

## What's NOT in this PR (deliberate skips, suggested follow-ups)

- **\`npm run lint\` in CI**: pre-existing 4 ESLint errors (\`react-refresh/only-export-components\` from shadcn-pattern files). Adding the step now would break CI. Needs a separate PR to either configure exceptions for shadcn-style components or split the offending files.
- **\`size-limit-action\`**: high-signal for a Vite SPA but adds a config file + per-PR check. Worth a follow-up.
- **\`treosh/lighthouse-ci-action\`**: gates perf/a11y/SEO on every PR. Worth it once the site is more feature-complete.
- **\`aquasecurity/trivy-action\`**: scans the nginx Docker image. Cheap insurance for the Cloud Run deployment.
- **OSSF Scorecard**: free public-repo scorecard with a badge. Mostly cosmetic for a portfolio.
- **CODEOWNERS**: existing ruleset has \`require_code_owner_review: true\` but no CODEOWNERS file (no-op). Adding \`* @seanbearden\` to CODEOWNERS would activate the rule and lock you out of self-merging since GitHub doesn't allow PR authors to approve their own PRs. Recommend either removing \`require_code_owner_review\` from the ruleset, or skipping CODEOWNERS for now.

## Cost

\$0. Everything is free for public repos.

## Test plan

- [ ] CI green on this PR (the new files don't affect build)
- [ ] After merge: CodeQL run completes and "Code scanning" tab populates
- [ ] After merge: Dependabot opens its first batch of PRs (likely several stale deps)
- [ ] After merge: visit https://github.com/seanbearden/portfolio/security/advisories/new — should show the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)