### PR TITLE
ci: skip Quality checks on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   quality:
     name: Quality checks
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary

Stops the \`Quality checks\` job from running while a PR is in draft, to avoid burning Actions minutes on work the author isn't ready to validate yet.

## How it works

Two paired changes:

1. **Trigger:** \`types: [opened, synchronize, reopened, ready_for_review]\` — adds \`ready_for_review\` so CI fires *once* when a draft is promoted to a normal PR.
2. **Job guard:** \`if: github.event_name != 'pull_request' || github.event.pull_request.draft == false\` — skips the job when triggered by a draft. The OR clause keeps \`push\` events on \`main\` working unchanged.

Without both, drafts still run on \`synchronize\` events.

## What it covers / doesn't

- ✅ Drafted feature branches: silent until ready_for_review
- ✅ Draft Dependabot PRs (rare but possible)
- ✅ \`push\` on main: unaffected, runs as before
- ❌ \`Deploy\` workflow: triggered by tag push, not PR — unaffected
- ❌ \`Release\` workflow: triggered by push to main — unaffected
- ❌ CodeQL default setup: managed by GitHub, separate behavior; respects draft state by default

## Note on cost

Public repos get unlimited Actions minutes, so this is precautionary rather than dollar-saving. Still useful: faster iteration on drafts (no waiting for CI on every push) and cleaner check history.

## Test plan

- [ ] CI runs on this PR (it's not a draft)
- [ ] After merge: open a new draft PR — verify no \`Quality checks\` run appears
- [ ] Convert that draft to ready — verify CI fires once

🤖 Generated with [Claude Code](https://claude.com/claude-code)