### PR TITLE
chore: backfill changesets before v0.3.0 release

### DIFF
--- a/.changeset/minor-and-patch-group-q2-2026.md
+++ b/.changeset/minor-and-patch-group-q2-2026.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Bump shipped runtime dependencies in the Dependabot minor-and-patch group: `react` 19.2.4 → 19.2.5, `react-dom` 19.2.4 → 19.2.5, `react-router` 7.14.0 → 7.14.2, `@base-ui/react` 1.3.0 → 1.4.1, `lucide-react` 1.7.0 → 1.14.0, plus build-tool patches (`tailwindcss`, `@tailwindcss/vite`, `shadcn`).

--- a/.changeset/nginx-bump.md
+++ b/.changeset/nginx-bump.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Bump nginx Docker base image from `1.27-alpine` to `1.29-alpine` for the runtime container served from Cloud Run.

--- a/.changeset/social-icons-refactor.md
+++ b/.changeset/social-icons-refactor.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Refactor social icon mapping into a unified `SocialIcons` component shared between Header, Footer, and ContactPage. No visual change.

--- a/.changeset/vite-bump.md
+++ b/.changeset/vite-bump.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Bump Vite 8.0.3 → 8.0.10 (patch updates from upstream). Affects the production bundle output.


### PR DESCRIPTION
## Summary

Final pre-release changeset audit for PR #10. Adds entries for 4 merged PRs that shipped runtime/build changes without a changeset.

## Added (4 patches)

| PR | Bump | Why a changeset |
|----|------|-----------------|
| #40 | patch | \`SocialIcons\` refactor — frontend code |
| #46 | patch | Vite 8.0.3 → 8.0.10 — affects bundle output |
| #50 | patch | nginx 1.27-alpine → 1.29-alpine — runtime container served by Cloud Run |
| #53 | patch | Dependabot minor-and-patch group — includes shipped deps: react, react-dom, react-router, @base-ui/react, lucide-react |

## Verified skipped (no changeset needed, per AGENTS.md skip rules)

- \`.github/workflows/**\` only: #34, #38, #41, #51, #52
- \`*.md\` / templates only: #36, #47
- \`scripts/**\` only: #42
- \`infrastructure/**\` only: #49
- Build-stage Docker base (Node): #48
- devDeps not in runtime bundle (eslint, @types/node, type-checking): #54, #56, #57
- Lockfile-only or non-shipped: #43 (postcss devDep), #44, #45 (hono — not in package.json on main)
- Already had changesets: #11–18, #20, #22, #23, #28–33, #39, #55, #58

## After merge

PR #10 (\`release: version packages\`) will auto-rebuild via the \`Release\` workflow and pick up these 4 entries. Then merging #10 cuts \`v0.3.0\` and triggers the deploy.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: PR #10 updates, body shows 4 new bullets under "portfolio@0.3.0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)