### PR TITLE
ci: add minimal GITHUB_TOKEN permissions (resolves CodeQL alert #2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Quality checks


### PR DESCRIPTION
## Summary

Resolves [CodeQL alert #2](https://github.com/seanbearden/portfolio/security/code-scanning/2) — \`actions/missing-workflow-permissions\` (medium severity).

The CI workflow had no explicit \`permissions\` block, so \`GITHUB_TOKEN\` inherited the repo default, which is broader than CI needs. Adds:

\`\`\`yaml
permissions:
  contents: read
\`\`\`

at the workflow level, which applies to all jobs in the file. CI only checks out code, runs \`npm ci\`, typechecks, tests, and builds — none of which need write access.

## Other workflows (already correct, not touched)

| Workflow | Permissions | Why |
|----------|-------------|-----|
| \`release.yml\` | \`contents: write\` | Creates release tags |
| \`deploy.yml\` | \`contents: read\`, \`id-token: write\` | Reads code, OIDC to GCP |
| \`auto-label-issues.yml\` | \`issues: write\` | Adds \`jules\` label |

## Test plan

- [ ] CI green on this PR (with the new restrictive permissions)
- [ ] After merge: CodeQL re-scans \`ci.yml\` and alert #2 closes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)