### PR TITLE
ci: add Codecov Test Analytics + README coverage badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,20 @@ jobs:
       - run: npm run build
 
       - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: frontend/coverage/lcov.info
           flags: frontend
           fail_ci_if_error: false
-          verbose: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: frontend/test-report.junit.xml
+          report-type: test_results
+          flags: frontend
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # Sean Bearden — Portfolio Website
 
+[![codecov](https://codecov.io/gh/seanbearden/portfolio/graph/badge.svg?token=JgoqNrfl9G)](https://codecov.io/gh/seanbearden/portfolio)
+
 Personal portfolio website for Sean Bearden, Ph.D. — self-hosted on Google Cloud, migrated from Squarespace.
 
 ## Architecture
 
 ![Architecture](sean_bearden_website_outline.svg)
+
+## Coverage
+
+[![Sunburst](https://codecov.io/gh/seanbearden/portfolio/graphs/sunburst.svg?token=JgoqNrfl9G)](https://codecov.io/gh/seanbearden/portfolio)
+
+The inner ring is `frontend/`; outer rings are subdirectories and files. Color = covered (green) vs uncovered (red).
 
 **Stack:** React 19 + Vite + TypeScript + Shadcn/ui + Tailwind CSS, served by nginx on Cloud Run.
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 coverage
+test-report.junit.xml
 *.local
 
 # Editor directories and files

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
     },
   },
   test: {
+    reporters: process.env.CI
+      ? ['default', ['junit', { suiteName: 'portfolio-frontend' }]]
+      : ['default'],
+    outputFile: { junit: './test-report.junit.xml' },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'json-summary'],


### PR DESCRIPTION
## Summary

Cherry-picked from \`chore/codecov-setup\` (PR #64 merged before this commit landed). Adds Codecov's **Test Analytics** layer on top of the coverage setup, plus the badges you provided for the README.

## What Test Analytics gives you

Same \`CODECOV_TOKEN\`, no new infra. Free for public repos.

- **Failed-test details in PR comments** — when a test fails, the existing Codecov comment grows a "Tests" section with the failed-test name and stack trace
- **Flaky-test detection** — Codecov tracks pass-on-retry across \`main\`'s history (60-day retention) and surfaces tests that fail intermittently
- **Run-time / failure-rate trends** — viewable in the new "Tests" tab on codecov.io

The Codecov UI tab is silent by default on green PRs; only surfaces when there's a failure or flake.

## Files

| File | Change |
|------|--------|
| \`frontend/vite.config.ts\` | Add \`reporters\` (default + JUnit) and \`outputFile\` for the JUnit XML. Local dev unchanged; JUnit only emits when \`process.env.CI\` is set. |
| \`frontend/.gitignore\` | Ignore \`test-report.junit.xml\` |
| \`.github/workflows/ci.yml\` | Add a 2nd \`codecov-action@v5\` step with \`report-type: test_results\`. Both upload steps gated on \`if: !cancelled()\` so failure data still uploads (Codecov needs failures to compute flake rate). |
| \`README.md\` | Coverage badge near the top + sunburst chart in a new "Coverage" section |

## Important: choice of action

The historically-recommended \`codecov/test-results-action\` was **deprecated in v1.2.1 (Nov 2025)** in favor of \`codecov/codecov-action@v5\` with \`report-type: test_results\`. We use the post-deprecation path from the start.

## Note on the badge tokens

The token in the README badges (\`JgoqNrfl9G\`) is Codecov's **graph token** — a read-only token scoped only to badge/sunburst image rendering. It is *not* the upload token (\`CODECOV_TOKEN\` secret) and is safe to commit to public markdown. Codecov designs it for exactly this use.

## Local verification

\`\`\`
$ CI=1 npm test
Test Files  4 passed (4)
Tests       14 passed (14)
JUNIT report written to /…/frontend/test-report.junit.xml
\`\`\`

## Test plan

- [ ] CI green on this PR
- [ ] After merge: \`CODECOV_TOKEN\` (already required for coverage upload) covers test results too
- [ ] Open the next PR — Codecov's existing PR comment should now include test counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)