### PR TITLE
🧹 [code health] Make `oldUrl` in `BlogPost` optional

### DIFF
--- a/frontend/src/types/content.ts
+++ b/frontend/src/types/content.ts
@@ -2,7 +2,7 @@ export interface BlogPost {
   title: string;
   date: string;
   slug: string;
-  oldUrl: string;
+  oldUrl?: string;
   categories: string[];
   tags: string[];
   image?: string;

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -30,7 +30,7 @@ export function parseAndSortBlogPosts(modules: Record<string, unknown>): BlogPos
       title: (meta.title as string) ?? "",
       date: (meta.date as string) ?? "",
       slug: (meta.slug as string) ?? "",
-      oldUrl: (meta.oldUrl as string) ?? "",
+      oldUrl: meta.oldUrl as string | undefined,
       categories: (meta.categories as string[]) ?? [],
       tags: (meta.tags as string[]) ?? [],
       image: meta.image as string | undefined,


### PR DESCRIPTION
🎯 **What:** Changed `oldUrl` in `frontend/src/types/content.ts` from `string` to `string | undefined`, and updated `frontend/src/utils/content.ts` to reflect this change (using `undefined` rather than coercing undefined to `""`).

💡 **Why:** A `nullish` coalescing operation (`?? ""`) in the content parser resulted in blog posts without an `oldUrl` having an empty string. This creates a risk where lookups on the `oldUrl` property could accidentally match the wrong items. By typing it properly as `string | undefined`, the parsing and lookup logic remains clear and safe.

✅ **Verification:**
1. Built successfully and checked diff to ensure clean code formatting.
2. The `frontend` vitest suite passed successfully without errors (including `redirects.test.ts` which depends on these properties).

✨ **Result:** Improved maintainability and prevents a latent lookup bug without modifying behavior.

---
*PR created automatically by Jules for task [997147391135447397](https://jules.google.com/task/997147391135447397) started by @seanbearden*