### PR TITLE
ci: migrate CodeQL to Advanced Setup with draft-skip

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "**.md"
+      - ".changeset/**"
+      - "infrastructure/**"
+      - "scripts/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "LICENSE"
+      - "SECURITY.md"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "README.md"
+      - "codecov.yml"
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Replaces CodeQL Default Setup with a custom workflow file. Two improvements:

1. **Skip draft PRs.** PR #10 (the rolling \`release: version packages\` PR) sits in draft for days while \`changesets/action\` force-updates it on every push to main. Default Setup ran CodeQL on every one of those updates — completely wasted compute.
2. **Skip non-shipped paths.** Docs, infra, scripts, content, and templates don't ship; no point scanning them.

Default Setup doesn't support either of these. Advanced Setup does.

## What's in the new workflow

\`\`\`yaml
on:
  push:        { branches: [main] }
  pull_request:
    branches: [main]
    types: [opened, synchronize, reopened, ready_for_review]
    paths-ignore: [docs, infra, scripts, content, etc.]
  schedule:    [Mondays 06:00 UTC]   # catch newly-discovered vulns

jobs.analyze.if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
\`\`\`

Same matrix as before (\`actions\` + \`javascript-typescript\`), \`security-and-quality\` query suite (slightly broader than the \`default\` suite — recommended for projects with security-sensitive code paths).

## Activation steps (one-time, manual)

CodeQL Default Setup and Advanced Setup are **mutually exclusive**. Until Default Setup is disabled, this new workflow won't run.

After merging this PR:

1. Go to **Settings → Code security → Code scanning**
2. Find the **Default setup** entry and click **Disable**
3. Confirm. The new workflow takes over on the next push.

I deliberately did NOT disable Default Setup myself — that's a meaningful security configuration change for the user to flip.

## What changes for PR #10 specifically

- While #10 is a draft: zero CodeQL runs (was many per week)
- When you mark it ready for review (right before merging the release): one CodeQL run fires
- After it merges: the push-to-main scan fires once on the resulting commit

## Test plan

- [ ] CI green on this PR
- [ ] After merge: disable Default Setup
- [ ] Open a draft PR — verify CodeQL doesn't run
- [ ] Mark it ready — verify CodeQL fires once
- [ ] Push another commit while ready — verify CodeQL re-runs (synchronize)

🤖 Generated with [Claude Code](https://claude.com/claude-code)