### PR TITLE
🧹 Fix inconsistent import.meta.glob string typings

### DIFF
--- a/frontend/src/utils/content.test.ts
+++ b/frontend/src/utils/content.test.ts
@@ -33,19 +33,7 @@ describe('parseAndSortBlogPosts', () => {
     expect(posts[1].title).toBe('No Date');
   });
 
-  it('should handle invalid string types in raw content gracefully', () => {
-    const mockModules = {
-      'valid.md': '---\ntitle: Valid\ndate: 2023-01-01\n---\nBody',
-      'invalid.md': null as unknown as string, // Simulating an edge case if import.meta.glob returns non-string
-    };
 
-    const posts = parseAndSortBlogPosts(mockModules);
-
-    expect(posts).toHaveLength(2);
-    expect(posts[0].title).toBe('Valid');
-    // The invalid one parses as empty string, so it will have empty date and go to the end
-    expect(posts[1].date).toBe('');
-  });
 });
 
 describe('getBlogPosts', () => {

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -21,11 +21,10 @@ const blogModules = import.meta.glob<string>("../../../content/blog/*.md", {
   import: "default",
 });
 
-export function parseAndSortBlogPosts(modules: Record<string, unknown>): BlogPost[] {
+export function parseAndSortBlogPosts(modules: Record<string, string>): BlogPost[] {
   const posts: BlogPost[] = [];
   for (const [, raw] of Object.entries(modules)) {
-    const content = typeof raw === "string" ? raw : "";
-    const { meta, body } = parseFrontmatter(content);
+    const { meta, body } = parseFrontmatter(raw);
     posts.push({
       title: (meta.title as string) ?? "",
       date: (meta.date as string) ?? "",
@@ -70,8 +69,7 @@ export function getProjects(): PortfolioProject[] {
 
   const projects: PortfolioProject[] = [];
   for (const [, raw] of Object.entries(portfolioModules)) {
-    const content = typeof raw === "string" ? raw : "";
-    const { meta, body } = parseFrontmatter(content);
+    const { meta, body } = parseFrontmatter(raw);
     projects.push({
       title: (meta.title as string) ?? "",
       subtitle: meta.subtitle as string | undefined,


### PR DESCRIPTION
🎯 **What:** Updated the parameter type of `parseAndSortBlogPosts` from `Record<string, unknown>` to `Record<string, string>`, and removed the `typeof raw === "string" ? raw : ""` fallback logic in both the blog post and portfolio parsing loops. Removed an obsolete test case that explicitly forced an invalid `null` type as raw content.

💡 **Why:** `import.meta.glob<string>` correctly returns a string since Vite automatically processes it with `query: '?raw'`. By correctly typing the input modules, we eliminated redundant runtime type checks. This aligns the Typescript typing directly with the output of Vite's bundler and avoids unnecessary operations, leading to improved code readability and maintainability.

✅ **Verification:** Verified by executing the test suite (`npm run test`) and confirming all tests pass. Removed one test case (`should handle invalid string types in raw content gracefully`) that simulated `import.meta.glob` returning `null` because the code is statically guaranteed to receive strings now. Checked lint rules and no regressions were introduced.

✨ **Result:** Better types and cleaner code. No changes to the application's runtime behavior.

---
*PR created automatically by Jules for task [5264794197586360927](https://jules.google.com/task/5264794197586360927) started by @seanbearden*