### PR TITLE
🧹 [Code Health] Fix inconsistent import.meta.glob typing and remove redundant checks

### DIFF
--- a/frontend/src/utils/content.test.ts
+++ b/frontend/src/utils/content.test.ts
@@ -32,20 +32,6 @@ describe('parseAndSortBlogPosts', () => {
     expect(posts[0].title).toBe('With Date');
     expect(posts[1].title).toBe('No Date');
   });
-
-  it('should handle invalid string types in raw content gracefully', () => {
-    const mockModules = {
-      'valid.md': '---\ntitle: Valid\ndate: 2023-01-01\n---\nBody',
-      'invalid.md': null as unknown as string, // Simulating an edge case if import.meta.glob returns non-string
-    };
-
-    const posts = parseAndSortBlogPosts(mockModules);
-
-    expect(posts).toHaveLength(2);
-    expect(posts[0].title).toBe('Valid');
-    // The invalid one parses as empty string, so it will have empty date and go to the end
-    expect(posts[1].date).toBe('');
-  });
 });
 
 describe('getBlogPosts', () => {

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -21,10 +21,10 @@ const blogModules = import.meta.glob<string>("../../../content/blog/*.md", {
   import: "default",
 });
 
-export function parseAndSortBlogPosts(modules: Record<string, unknown>): BlogPost[] {
+export function parseAndSortBlogPosts(modules: Record<string, string>): BlogPost[] {
   const posts: BlogPost[] = [];
   for (const [, raw] of Object.entries(modules)) {
-    const content = typeof raw === "string" ? raw : "";
+    const content = raw;
     const { meta, body } = parseFrontmatter(content);
     posts.push({
       title: (meta.title as string) ?? "",
@@ -70,7 +70,7 @@ export function getProjects(): PortfolioProject[] {
 
   const projects: PortfolioProject[] = [];
   for (const [, raw] of Object.entries(portfolioModules)) {
-    const content = typeof raw === "string" ? raw : "";
+    const content = raw;
     const { meta, body } = parseFrontmatter(content);
     projects.push({
       title: (meta.title as string) ?? "",


### PR DESCRIPTION
🎯 **What:** This addresses an inconsistent typing issue with `import.meta.glob` results in `frontend/src/utils/content.ts`. The parameter type of `parseAndSortBlogPosts` was updated from `Record<string, unknown>` to `Record<string, string>`. Additionally, redundant runtime type assertions (`typeof raw === "string" ? raw : ""`) were removed in `parseAndSortBlogPosts` and `getProjects`.

💡 **Why:** By standardizing the types to match the generic `import.meta.glob<string>`, we remove brittle runtime logic and align with strict TypeScript type checks. This improves readability and maintainability.

✅ **Verification:** Ran `npm run test` inside the frontend directory. The unit tests pass consistently. Also removed an outdated test simulating a non-string value (which the TypeScript typings naturally prevent). 

✨ **Result:** A cleaner utility file with strong typing relying heavily on standard definitions over runtime checks.

---
*PR created automatically by Jules for task [6236352790531028564](https://jules.google.com/task/6236352790531028564) started by @seanbearden*