### PR TITLE
🧹 chore: fix inconsistent typing for import.meta.glob results

### DIFF
--- a/frontend/src/utils/content.test.ts
+++ b/frontend/src/utils/content.test.ts
@@ -33,10 +33,10 @@ describe('parseAndSortBlogPosts', () => {
     expect(posts[1].title).toBe('No Date');
   });
 
-  it('should handle invalid string types in raw content gracefully', () => {
+  it('should handle empty raw content gracefully', () => {
     const mockModules = {
       'valid.md': '---\ntitle: Valid\ndate: 2023-01-01\n---\nBody',
-      'invalid.md': null as unknown as string, // Simulating an edge case if import.meta.glob returns non-string
+      'invalid.md': '' as string,
     };
 
     const posts = parseAndSortBlogPosts(mockModules);

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -21,11 +21,10 @@ const blogModules = import.meta.glob<string>("../../../content/blog/*.md", {
   import: "default",
 });
 
-export function parseAndSortBlogPosts(modules: Record<string, unknown>): BlogPost[] {
+export function parseAndSortBlogPosts(modules: Record<string, string>): BlogPost[] {
   const posts: BlogPost[] = [];
   for (const [, raw] of Object.entries(modules)) {
-    const content = typeof raw === "string" ? raw : "";
-    const { meta, body } = parseFrontmatter(content);
+    const { meta, body } = parseFrontmatter(raw || "");
     posts.push({
       title: (meta.title as string) ?? "",
       date: (meta.date as string) ?? "",
@@ -70,8 +69,7 @@ export function getProjects(): PortfolioProject[] {
 
   const projects: PortfolioProject[] = [];
   for (const [, raw] of Object.entries(portfolioModules)) {
-    const content = typeof raw === "string" ? raw : "";
-    const { meta, body } = parseFrontmatter(content);
+    const { meta, body } = parseFrontmatter(raw || "");
     projects.push({
       title: (meta.title as string) ?? "",
       subtitle: meta.subtitle as string | undefined,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Updated `parseAndSortBlogPosts` parameter type from `Record<string, unknown>` to `Record<string, string>` and removed redundant `typeof raw === "string"` checks for `import.meta.glob<string>` modules. Adjusted tests to remove invalid typing edge-cases.

💡 **Why:** How this improves maintainability
The codebase was using an overly defensive type assertion `typeof raw === "string"` which is unnecessary when `import.meta.glob<string>` already enforces strings. This improves TypeScript accuracy and simplifies the content parsers.

✅ **Verification:** How you confirmed the change is safe
Passed type checking via `npm run build` and updated/ran `vitest` unit tests successfully.

✨ **Result:** The improvement achieved
Cleaned up types and parsing loops in `frontend/src/utils/content.ts`, achieving a safer and less noisy implementation.

---
*PR created automatically by Jules for task [8038867639000895050](https://jules.google.com/task/8038867639000895050) started by @seanbearden*