### PR TITLE
ci: enrich Codecov PR comment (newheader + components)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -20,15 +20,42 @@ coverage:
         informational: true
 
 comment:
-  layout: "reach, diff, flags, files"
+  layout: "newheader, diff, flags, components, files, condensed_footer"
   behavior: default
   require_changes: false
+  hide_comment_details: true
+  show_carryforward_flags: false
 
 flags:
   frontend:
     paths:
       - frontend/src/
     carryforward: false
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+        informational: true
+  individual_components:
+    - component_id: pages
+      name: Pages
+      paths:
+        - frontend/src/pages/**
+    - component_id: components
+      name: Components
+      paths:
+        - frontend/src/components/**
+    - component_id: utils
+      name: Utils
+      paths:
+        - frontend/src/utils/**
+    - component_id: lib
+      name: Lib
+      paths:
+        - frontend/src/lib/**
 
 ignore:
   - "infrastructure/**"


### PR DESCRIPTION
## Why your comment was sparse

It's NOT the free tier — public repos get the same PR-comment features as paid plans (PR Comments, Patch+Project coverage, Flags, Components are all checkmarked on Free per [pricing](https://about.codecov.io/pricing/)). The sparseness on #68 came from three things:

1. **Layout missing modern components** — \`reach\` is legacy; \`newheader\` and \`components\` weren't included
2. **100% diff coverage triggers auto-collapse** — Codecov hides the files/flags/components sections when nothing changed and replaces them with the "All modified and coverable lines are covered" message
3. **No \`component_management\` defined** — even if \`components\` was in the layout, there was nothing to render

\`teleport-platform\` looks richer because they probably define components.

## Changes

### `codecov.yml` layout
\`\`\`diff
- layout: "reach, diff, flags, files"
+ layout: "newheader, diff, flags, components, files, condensed_footer"
+ hide_comment_details: true
+ show_carryforward_flags: false
\`\`\`

### New `component_management` block

Splits coverage by logical area:
- **Pages** → \`frontend/src/pages/**\`
- **Components** → \`frontend/src/components/**\`
- **Utils** → \`frontend/src/utils/**\`
- **Lib** → \`frontend/src/lib/**\`

Each gets its own informational status check and a row in the PR comment showing its individual coverage delta. This is the change that will give you per-area visibility into where coverage drops happen.

## What you'll see post-merge

On a non-trivial PR, the comment now has:
- **newheader** — base/head commits, total coverage delta, diff coverage at the top
- **diff** — coverage diff table
- **flags** — `frontend` flag row
- **components** — Pages/Components/Utils/Lib rows ← **new**
- **files** — impacted files
- **condensed_footer** — compact legend + last-updated link

On a 100% diff coverage PR like #68, the comment will still auto-collapse some sections, but the components panel will still render baseline coverage for each area.

## NOT included

**Bundle Analysis** (`@codecov/vite-plugin`) — would add bundle-size delta to the PR comment. Currently blocked: the plugin's peer deps are `vite@4.x || 5.x || 6.x` and this repo is on Vite 8. Re-evaluate when the plugin updates.

## Cost

\$0. All these features are on Codecov's Free tier for public repos.

## Test plan

- [ ] CI green on this PR
- [ ] Codecov updates the comment on this PR using the new layout — verify components rows show
- [ ] Future non-trivial PRs show per-component coverage deltas

🤖 Generated with [Claude Code](https://claude.com/claude-code)