### PR TITLE
Add unit tests for cn utility (100% Lib coverage)

### DIFF
--- a/.changeset/add-cn-tests.md
+++ b/.changeset/add-cn-tests.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Add tests for cn() utility (Lib coverage to 100%).

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { cn } from "./utils";
+
+describe("cn", () => {
+  it("merges multiple class strings", () => {
+    expect(cn("a", "b", "c")).toBe("a b c");
+  });
+
+  it("dedupes conflicting Tailwind classes (twMerge behavior)", () => {
+    // twMerge is the whole point — last-wins for conflicting Tailwind utilities
+    expect(cn("p-2", "p-4")).toBe("p-4");
+    expect(cn("text-red-500", "text-blue-500")).toBe("text-blue-500");
+  });
+
+  it("handles conditional classes via clsx", () => {
+    expect(cn("base", false && "hidden", true && "visible")).toBe("base visible");
+    expect(cn("base", null, undefined, "")).toBe("base");
+  });
+
+  it("handles array and object syntax (clsx behavior)", () => {
+    expect(cn(["a", "b"])).toBe("a b");
+    expect(cn({ "a": true, "b": false, "c": true })).toBe("a c");
+  });
+
+  it("returns empty string when no truthy classes provided", () => {
+    expect(cn()).toBe("");
+    expect(cn(false, null, undefined)).toBe("");
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for the `cn` utility in `frontend/src/lib/utils.ts` to achieve 100% test coverage for the Lib component.

Key changes:
- Created `frontend/src/lib/utils.test.ts` with tests for:
  - Basic string merging
  - Tailwind class deduping (via `twMerge`)
  - Conditional classes (via `clsx`)
  - Array and object syntax support
  - Empty/falsy input handling
- Added a patch changeset to document the new tests.

Verified that all 18 frontend tests pass and that `src/lib/utils.ts` has 100% coverage according to `npm run test:coverage`.

Fixes #80

---
*PR created automatically by Jules for task [13031827866144620786](https://jules.google.com/task/13031827866144620786) started by @seanbearden*