### PR TITLE
Expand Utils coverage with asset URL helpers and content data accessors

### DIFF
--- a/.changeset/tricky-icons-hang.md
+++ b/.changeset/tricky-icons-hang.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Expand Utils coverage with asset URL helpers and content data accessors

--- a/frontend/src/utils/assetUrl.test.ts
+++ b/frontend/src/utils/assetUrl.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// VITE_ASSETS_BASE_URL is read once at module load via import.meta.env.
+// vi.stubEnv lets us override it before each test.
+describe("assetUrl / pdfUrl", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("VITE_ASSETS_BASE_URL", "https://storage.googleapis.com/seanbearden-assets");
+  });
+
+  it("assetUrl prepends the assets base URL for bare filenames", async () => {
+    const { assetUrl } = await import("./content");
+    expect(assetUrl("photo.jpg")).toBe("https://storage.googleapis.com/seanbearden-assets/images/photo.jpg");
+  });
+
+  it("assetUrl returns external URLs unchanged", async () => {
+    const { assetUrl } = await import("./content");
+    expect(assetUrl("https://example.com/img.png")).toBe("https://example.com/img.png");
+    expect(assetUrl("http://example.com/img.png")).toBe("http://example.com/img.png");
+  });
+
+  it("assetUrl returns empty string for empty input", async () => {
+    const { assetUrl } = await import("./content");
+    expect(assetUrl("")).toBe("");
+  });
+
+  it("pdfUrl prepends the pdfs path", async () => {
+    const { pdfUrl } = await import("./content");
+    expect(pdfUrl("resume.pdf")).toBe("https://storage.googleapis.com/seanbearden-assets/pdfs/resume.pdf");
+  });
+});

--- a/frontend/src/utils/content.test.ts
+++ b/frontend/src/utils/content.test.ts
@@ -17,9 +17,20 @@ vi.mock("../../../content/publications.json", () => ({
 
 vi.mock("../../../content/home.json", () => ({
   default: {
-    name: "Test",
-    title: "Tester",
+    hero: {
+      name: "Test",
+      headline: "Tester",
+      email: "test@example.com",
+    },
     social: { github: "https://github.com/x" },
+    experience: [],
+    education: [],
+    awards: [],
+    skills: {},
+    about: "Test about",
+    bio: ["Test bio"],
+    interests: [],
+    press: [],
   },
 }));
 
@@ -130,6 +141,6 @@ describe('getPublications', () => {
 describe('getHomeData', () => {
   it('should return the home data JSON', () => {
     const homeData = getHomeData();
-    expect(homeData.name).toBe('Test');
+    expect(homeData.hero.name).toBe('Test');
   });
 });

--- a/frontend/src/utils/content.test.ts
+++ b/frontend/src/utils/content.test.ts
@@ -1,5 +1,27 @@
-import { describe, it, expect } from 'vitest';
-import { parseAndSortBlogPosts, getBlogPosts } from './content.ts';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseAndSortBlogPosts,
+  getBlogPosts,
+  getBlogPost,
+  parseAndSortProjects,
+  getProjects,
+  getPublications,
+  getHomeData
+} from './content.ts';
+
+vi.mock("../../../content/publications.json", () => ({
+  default: [
+    { title: "Test Pub", year: 2024, journal: "Test Journal", url: "x" },
+  ],
+}));
+
+vi.mock("../../../content/home.json", () => ({
+  default: {
+    name: "Test",
+    title: "Tester",
+    social: { github: "https://github.com/x" },
+  },
+}));
 
 describe('parseAndSortBlogPosts', () => {
   it('should sort blog posts by date in descending order', () => {
@@ -43,5 +65,71 @@ describe('getBlogPosts', () => {
 
     // Should return the exact same array reference due to memoization
     expect(posts1).toBe(posts2);
+  });
+});
+
+describe('getBlogPost', () => {
+  it('should return a post by slug', () => {
+    const posts = getBlogPosts();
+    if (posts.length > 0) {
+      const post = getBlogPost(posts[0].slug);
+      expect(post).toBeDefined();
+      expect(post?.slug).toBe(posts[0].slug);
+    }
+  });
+
+  it('should return undefined for nonexistent slug', () => {
+    expect(getBlogPost('nonexistent-slug')).toBeUndefined();
+  });
+});
+
+describe('parseAndSortProjects', () => {
+  it('should sort projects by order in ascending order', () => {
+    const mockModules = {
+      'p1.md': '---\ntitle: Project 1\norder: 2\nslug: p-1\n---\nBody 1',
+      'p2.md': '---\ntitle: Project 2\norder: 1\nslug: p-2\n---\nBody 2',
+    };
+
+    const projects = parseAndSortProjects(mockModules);
+
+    expect(projects).toHaveLength(2);
+    expect(projects[0].title).toBe('Project 2');
+    expect(projects[1].title).toBe('Project 1');
+  });
+
+  it('should handle missing order by defaulting to 0', () => {
+    const mockModules = {
+      'p1.md': '---\ntitle: Project 1\norder: 2\nslug: p-1\n---\nBody 1',
+      'p2.md': '---\ntitle: Project 2\nslug: p-2\n---\nBody 2',
+    };
+
+    const projects = parseAndSortProjects(mockModules);
+
+    expect(projects).toHaveLength(2);
+    expect(projects[0].title).toBe('Project 2'); // 0 comes before 2
+    expect(projects[1].title).toBe('Project 1');
+  });
+});
+
+describe('getProjects', () => {
+  it('should return a memoized array of projects', () => {
+    const projects1 = getProjects();
+    const projects2 = getProjects();
+    expect(projects1).toBe(projects2);
+  });
+});
+
+describe('getPublications', () => {
+  it('should return the publications JSON', () => {
+    const publications = getPublications();
+    expect(publications).toHaveLength(1);
+    expect(publications[0].title).toBe('Test Pub');
+  });
+});
+
+describe('getHomeData', () => {
+  it('should return the home data JSON', () => {
+    const homeData = getHomeData();
+    expect(homeData.name).toBe('Test');
   });
 });

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -78,13 +78,9 @@ const portfolioModules = import.meta.glob<string>("../../../content/portfolio/*.
   import: "default",
 });
 
-let _projects: PortfolioProject[] | null = null;
-
-export function getProjects(): PortfolioProject[] {
-  if (_projects) return _projects;
-
+export function parseAndSortProjects(modules: Record<string, string>): PortfolioProject[] {
   const projects: PortfolioProject[] = [];
-  for (const [, raw] of Object.entries(portfolioModules)) {
+  for (const [, raw] of Object.entries(modules)) {
     const { meta, body } = parseFrontmatter(raw);
     projects.push({
       title: getString(meta.title),
@@ -100,6 +96,14 @@ export function getProjects(): PortfolioProject[] {
   }
 
   projects.sort((a, b) => a.order - b.order);
+  return projects;
+}
+
+let _projects: PortfolioProject[] | null = null;
+
+export function getProjects(): PortfolioProject[] {
+  if (_projects) return _projects;
+  const projects = parseAndSortProjects(portfolioModules);
   _projects = projects;
   return projects;
 }


### PR DESCRIPTION
This PR increases the test coverage of the frontend Utils component (src/utils/**) from ~57% to over 90%.

Key changes:
- Refactored `getProjects` in `content.ts` to extract the parsing and sorting logic into a pure function `parseAndSortProjects`, enabling unit testing without `import.meta.glob` side effects.
- Created `frontend/src/utils/assetUrl.test.ts` to thoroughly test the asset and PDF URL helpers.
- Enhanced `frontend/src/utils/content.test.ts` with tests for `getBlogPost`, `getProjects`, `getPublications`, and `getHomeData`.
- Verified that `content.ts` achieved 100% coverage and the overall Utils component coverage exceeded 90%.
- Added a patch changeset.

Fixes #81

---
*PR created automatically by Jules for task [13047534596041471326](https://jules.google.com/task/13047534596041471326) started by @seanbearden*