### PR TITLE
ci: add ZAP baseline + Mozilla Observatory scans

### DIFF
--- a/.github/workflows/security-headers.yml
+++ b/.github/workflows/security-headers.yml
@@ -1,0 +1,78 @@
+name: Security Headers
+
+on:
+  schedule:
+    - cron: "30 6 * * 1"  # Mondays 06:30 UTC, just after ZAP
+  workflow_dispatch:
+    inputs:
+      host:
+        description: "Hostname (no scheme) to scan"
+        required: false
+        default: "seanbearden.com"
+      min_grade:
+        description: "Minimum acceptable Mozilla Observatory grade"
+        required: false
+        default: "B"
+
+permissions:
+  contents: read
+
+jobs:
+  observatory:
+    name: Mozilla Observatory scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      HOST: ${{ github.event.inputs.host || 'seanbearden.com' }}
+      MIN_GRADE: ${{ github.event.inputs.min_grade || 'B' }}
+    steps:
+      - name: Trigger and read scan
+        run: |
+          set -euo pipefail
+          response=$(curl -sS -X POST \
+            "https://observatory-api.mdn.mozilla.net/api/v2/scan?host=${HOST}")
+          echo "$response" | jq .
+
+          grade=$(echo "$response" | jq -r '.grade')
+          score=$(echo "$response" | jq -r '.score')
+          passed=$(echo "$response" | jq -r '.tests_passed')
+          failed=$(echo "$response" | jq -r '.tests_failed')
+          details=$(echo "$response" | jq -r '.details_url')
+
+          {
+            echo "## Mozilla Observatory: ${HOST}"
+            echo ""
+            echo "- **Grade**: ${grade}"
+            echo "- **Score**: ${score}"
+            echo "- **Tests passed**: ${passed} / $((passed + failed))"
+            echo "- **Details**: ${details}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Grade comparison: A+ > A > A- > B+ > B > B- > C+ > C > C- > D+ > D > D- > F
+          rank() {
+            case "$1" in
+              "A+") echo 13 ;;
+              "A")  echo 12 ;;
+              "A-") echo 11 ;;
+              "B+") echo 10 ;;
+              "B")  echo 9 ;;
+              "B-") echo 8 ;;
+              "C+") echo 7 ;;
+              "C")  echo 6 ;;
+              "C-") echo 5 ;;
+              "D+") echo 4 ;;
+              "D")  echo 3 ;;
+              "D-") echo 2 ;;
+              "F")  echo 1 ;;
+              *)    echo 0 ;;
+            esac
+          }
+
+          got=$(rank "$grade")
+          want=$(rank "$MIN_GRADE")
+
+          if [ "$got" -lt "$want" ]; then
+            echo "::error::Observatory grade ${grade} is below minimum ${MIN_GRADE}"
+            exit 1
+          fi
+          echo "Observatory grade ${grade} meets minimum ${MIN_GRADE}"

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -1,0 +1,44 @@
+name: ZAP Baseline
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "frontend/**"
+      - "nginx.conf.template"
+      - "Dockerfile"
+      - ".zap/**"
+      - ".github/workflows/zap-baseline.yml"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "URL to scan"
+        required: false
+        default: "https://seanbearden.com"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  baseline:
+    name: ZAP baseline scan
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run ZAP baseline scan
+        uses: zaproxy/action-baseline@v0.15.0
+        with:
+          target: ${{ github.event.inputs.target || 'https://seanbearden.com' }}
+          docker_name: "ghcr.io/zaproxy/zaproxy:stable"
+          rules_file_name: ".zap/rules.tsv"
+          cmd_options: "-a"
+          fail_action: false
+          allow_issue_writing: true
+          artifact_name: "zap-baseline-report"

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,6 @@
+# ZAP Baseline rule overrides
+# Format: RULE_ID<TAB>IGNORE|WARN|FAIL<TAB>comment
+# Docs: https://www.zaproxy.org/docs/docker/baseline-scan/#configuration-file
+#
+# Add entries below as findings are triaged. Each IGNORE must include
+# a short comment explaining why the rule is acceptable for this site.


### PR DESCRIPTION
## Summary
- Adds `zap-baseline.yml` — `zaproxy/action-baseline@v0.15.0` passive scan against `https://seanbearden.com`. Runs weekly (Mon 06:00 UTC), on PRs touching `frontend/**`, `nginx.conf.template`, `Dockerfile`, or `.zap/**`, and on manual dispatch. `fail_action: false` while findings are being triaged; ZAP auto-manages a single tracking issue. Alpha passive rules enabled (`-a`).
- Adds `security-headers.yml` — Mozilla Observatory v2 API check with configurable minimum grade (default `B`). High-signal companion that catches header regressions in seconds vs ZAP's minutes. Probed against `seanbearden.com` during dev — current grade is **F**, so this will surface real issues immediately.
- Adds `.zap/rules.tsv` — empty placeholder for IGNOREs that get added (with comments) after the first run is triaged.

## Why these choices
- **Baseline (passive) over Active or AF**: site is a static unauthenticated SPA. Active scanning sends attack payloads — pointless and rude against prod, and the Automation Framework's extra config buys nothing without auth flows or APIs.
- **Production target**: passive scan is safe against the live site, and the cron catches CDN/edge/header changes that happen post-deploy. PR-preview-revision scanning is a future upgrade if needed.
- **Observatory companion**: ~80% of realistic findings on a static SPA are header-related. Observatory grades that in seconds with no Docker pull, complementing ZAP's deeper passive analysis.
- **No SARIF**: action-baseline doesn't emit SARIF natively; converters are unofficial. CodeQL already populates the Security tab. Auto-issue is the lower-friction surface for solo work.
- **No changeset**: workflow-only change, on the `.github/workflows/**` skip-list per `AGENTS.md`.

## Test plan
- [ ] CI runs both new workflows on this PR (ZAP triggers because `.github/workflows/zap-baseline.yml` is in the watched paths; Observatory only runs on schedule/dispatch — verify by manual `gh workflow run security-headers.yml` after merge).
- [ ] Confirm ZAP scan completes within 15-min timeout and produces an artifact + opens/updates a GitHub issue.
- [ ] Triage the ZAP issue: any IGNOREs go into `.zap/rules.tsv` with rationale, real findings get follow-up issues.
- [ ] Confirm Observatory workflow surfaces current grade in the run summary; expected to fail until headers are improved (intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)