### PR TITLE
fix(release): use 'portfolio' package name in bootstrap-react-testing changeset

### DIFF
--- a/.changeset/bootstrap-react-testing.md
+++ b/.changeset/bootstrap-react-testing.md
@@ -1,5 +1,5 @@
 ---
-"frontend": patch
+"portfolio": patch
 ---
 
 Bootstrap React component testing with @testing-library/react + jsdom


### PR DESCRIPTION
## Summary
The Release workflow has been failing on `main` since PR #86 merged ([failed run](https://github.com/seanbearden/portfolio/actions/runs/25263074556/job/74073396202)) with:

> 🦋 error Error: Found changeset bootstrap-react-testing for package **frontend** which is not in the workspace

## Root cause
This repo doesn't have a monorepo workspace config (no \`workspaces\` in root \`package.json\`, no \`pnpm-workspace.yaml\`). Changesets only recognizes the root package, which is named \`portfolio\`. The \`frontend/\` package isn't visible to changesets resolution.

All other changesets correctly declare \`"portfolio": patch\` (verified: \`grep -l '"portfolio"' .changeset/*.md\` matches the rest, only this one used \`"frontend"\`). This one slipped through.

## Fix
One-line change: \`"frontend": patch\` → \`"portfolio": patch\`. Verified locally with \`npx changeset status\` — resolves cleanly post-fix.

## Test plan
- [ ] Release workflow succeeds when this merges to \`main\`
- [ ] Rolling \"release: version packages\" PR (#10) updates to include this changeset's entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)