### PR TITLE
ci(zap): trigger weekly + after successful deploys

### DIFF
--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -3,15 +3,9 @@ name: ZAP Baseline
 on:
   schedule:
     - cron: "0 6 * * 1"  # Mondays 06:00 UTC
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - "frontend/**"
-      - "nginx.conf.template"
-      - "Dockerfile"
-      - ".zap/**"
-      - ".github/workflows/zap-baseline.yml"
+  workflow_run:
+    workflows: ["Deploy"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       target:
@@ -26,7 +20,7 @@ permissions:
 jobs:
   baseline:
     name: ZAP baseline scan
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Why
Two things were wrong with the original PR triggers, and \`push: branches: [main]\` (initial fix in this PR) only fixed half of it:

1. **PR trigger gave zero PR-specific signal** — ZAP scans the live \`seanbearden.com\` URL, so the scan target was unchanged production regardless of what the PR changed.
2. **Main pushes don't equal deploys** — only tag pushes (\`v*\`) trigger the Deploy workflow. Scanning on every main commit (not all of which ship) means scans run before the new revision is live, and run multiple times for what's effectively the same prod state.

## What
- Replace \`push\` trigger with \`workflow_run\` on the Deploy workflow:
  ```yaml
  workflow_run:
    workflows: [\"Deploy\"]
    types: [completed]
  ```
- Gate the job on \`workflow_run.conclusion == 'success'\` so failed/cancelled deploys don't trigger a scan.
- Weekly cron retained — safety net for CDN/edge header drift between deploys.
- \`workflow_dispatch\` retained for on-demand scans.

## After this
ZAP fires only at moments where the result can change:
- **After a successful Deploy completes** (the new prod state lands → re-scan)
- **Weekly Mondays 06:00 UTC** (drift catcher)
- **On manual dispatch** (debugging or pre-cutover validation)

## Test plan
- [ ] PR's own CI passes
- [ ] After merge, no ZAP runs are triggered by subsequent PRs or main pushes
- [ ] After the next \`v*\` tag deploy, ZAP runs once and posts an updated issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)