### PR TITLE
fix(codecov): rewrite lcov paths so 4 components actually match files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,12 @@ codecov:
   notify:
     wait_for_ci: true
 
+# vitest runs from frontend/ and emits lcov paths like "src/App.tsx".
+# Rewrite to "frontend/src/App.tsx" so component_management.paths and
+# flags.frontend.paths match against the repo-relative layout.
+fixes:
+  - "src/::frontend/src/"
+
 coverage:
   precision: 2
   round: down
@@ -43,19 +49,19 @@ component_management:
     - component_id: pages
       name: Pages
       paths:
-        - frontend/src/pages/**
+        - "frontend/src/pages/**"
     - component_id: components
       name: Components
       paths:
-        - frontend/src/components/**
+        - "frontend/src/components/**"
     - component_id: utils
       name: Utils
       paths:
-        - frontend/src/utils/**
+        - "frontend/src/utils/**"
     - component_id: lib
       name: Lib
       paths:
-        - frontend/src/lib/**
+        - "frontend/src/lib/**"
 
 ignore:
   - "infrastructure/**"


### PR DESCRIPTION
## Why

The 4 components in \`codecov.yml\` were configured but showed no data in the Codecov UI, and the per-component breakdown wasn't appearing in PR comments. **Not a Pro plan issue** — Codecov Components are free for public repos. The actual cause is a path-pattern mismatch:

| Source | Path format |
|---|---|
| \`frontend/coverage/lcov.info\` | \`SF:src/App.tsx\` (relative to where vitest ran) |
| \`codecov.yml\` component paths | \`frontend/src/pages/**\`, \`frontend/src/components/**\`, ... |

Codecov matches \`paths\` against the path **as it appears in the report** — it doesn't auto-prepend the repo's directory layout. With the prefix mismatch, no file ever matches a component, hence "configured, 0 data."

Verified by inspecting \`frontend/coverage/lcov.info\` directly:
```
SF:src/App.tsx
SF:src/components/common/SocialIcons.tsx
SF:src/components/layout/Footer.tsx
...
```

## What

Added a [\`fixes:\`](https://docs.codecov.com/docs/fixing-paths) rewrite rule:

```yaml
fixes:
  - \"src/::frontend/src/\"
```

This tells Codecov: when you receive a path starting with \`src/\`, rewrite it to \`frontend/src/\` before applying component / flag / ignore rules. The existing component glob patterns (\`frontend/src/pages/**\`, etc.) and the \`frontend\` flag's path filter both start matching after this rewrite.

Validated with \`curl -X POST --data-binary @codecov.yml https://api.codecov.io/validate\` → \`Valid!\`.

Also normalized quoting on component paths for consistency with \`ignore:\` patterns. No semantic difference.

## After this merges

Per the [Codecov Components docs](https://docs.codecov.com/docs/components):
1. Next coverage upload triggers re-evaluation.
2. PR comment will include the components breakdown (already in \`comment.layout\`: \`newheader, diff, flags, components, files, condensed_footer\`).
3. 4 new GitHub status checks appear on PRs: \`codecov/project/pages\`, \`codecov/project/components\`, \`codecov/project/utils\`, \`codecov/project/lib\`.
4. Codecov UI's **Components** tab will start showing per-component coverage; first time may need a click on **Enable Component Analytics** to backfill historical data.

Test Analytics is a separate feature and is **already wired** in \`ci.yml:44-52\` (uploads \`test-report.junit.xml\` with \`report-type: test_results\`). The link you sent (https://app.codecov.io/gh/seanbearden/portfolio/tests/new) is just the product onboarding — walk through it in the UI to flip the dashboard on; no further code changes needed.

## Test plan
- [ ] After merge, push a no-op or wait for the next PR/main upload.
- [ ] Check the Codecov PR comment shows the **Components** section populated.
- [ ] Confirm 4 new \`codecov/project/<component>\` status checks appear on the next PR.
- [ ] Open Components tab in Codecov UI → click \"Enable Component Analytics\" if prompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)