### PR TITLE
ci(codecov): migrate to dedicated test-results-action for Test Analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,9 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: frontend/test-report.junit.xml
-          report-type: test_results
           flags: frontend
           fail_ci_if_error: false


### PR DESCRIPTION
## Why
Codecov's Test Analytics onboarding (https://app.codecov.io/gh/seanbearden/portfolio/tests/new) won't register the repo as configured because we're using the **older** unified-action pattern:

\`\`\`yaml
uses: codecov/codecov-action@v5
with:
  report-type: test_results
\`\`\`

This still uploads JUnit results, but the Test Analytics dashboard detection looks for the dedicated \`codecov/test-results-action@v1\`.

## What
Swap the upload step:

\`\`\`diff
- uses: codecov/codecov-action@v5
+ uses: codecov/test-results-action@v1
   with:
     token: \${{ secrets.CODECOV_TOKEN }}
     files: frontend/test-report.junit.xml
-    report-type: test_results
     flags: frontend
     fail_ci_if_error: false
\`\`\`

JUnit XML is already produced via \`vite.config.ts\` reporters in CI mode (functionally equivalent to \`vitest --reporter=junit --outputFile=test-report.junit.xml\`).

## Test plan
- [ ] CI run succeeds and uploads complete on this PR
- [ ] After merge, Test Analytics page (\`/tests/new\` URL) shows the repo as configured
- [ ] Test Analytics dashboard begins populating with run history

🤖 Generated with [Claude Code](https://claude.com/claude-code)