### PR TITLE
test: stub IntersectionObserver/ResizeObserver/matchMedia for jsdom

### DIFF
--- a/.changeset/test-browser-api-stubs.md
+++ b/.changeset/test-browser-api-stubs.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Stub IntersectionObserver, ResizeObserver, and matchMedia in the test setup so framer-motion components can mount under jsdom without crashing.

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,34 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+// jsdom doesn't implement these browser APIs that framer-motion (and others)
+// use at mount time. Stub them so component renders don't crash.
+class IntersectionObserverStub {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = vi.fn(() => []);
+  root = null;
+  rootMargin = "";
+  thresholds = [];
+}
+
+class ResizeObserverStub {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+vi.stubGlobal("IntersectionObserver", IntersectionObserverStub);
+vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+
+vi.stubGlobal("matchMedia", (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));


### PR DESCRIPTION
## Why
**CI is currently red on \`main\`**. Framer-motion (added in #87) registers IntersectionObserver listeners on mount via \`whileInView\`. jsdom doesn't implement IntersectionObserver, so any test that mounts a component using motion features crashes with:

\`\`\`
ReferenceError: IntersectionObserver is not defined
  at initIntersectionObserver (framer-motion/src/motion/features/viewport/observers.ts:54:33)
  at observeIntersection (framer-motion/src/motion/features/viewport/observers.ts:68:38)
  at InViewFeature.startObserver (framer-motion/src/motion/features/viewport/index.ts:66:28)
\`\`\`

\`Footer.test.tsx\`, \`Header.test.tsx\`, and \`Layout.test.tsx\` (added in #88) all mount components that now use \`motion.*\` and \`whileInView\`. 4 tests fail on every CI run since #87 + #88 merged.

## What
Stub three browser APIs in \`src/test/setup.ts\` via \`vi.stubGlobal\`:
- **IntersectionObserver** — needed by framer-motion's \`whileInView\`
- **ResizeObserver** — defensive; framer-motion uses it for layout animations
- **matchMedia** — needed by \`useReducedMotion\` (queries \`prefers-reduced-motion\` at mount)

This is the standard fix; jsdom intentionally doesn't ship these.

## Test plan
- [x] \`npx vitest run\` passes all 40 tests locally
- [ ] CI passes on this PR
- [ ] After merge, main goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)