### PR TITLE
ci: pin 3rd-party Actions to commit SHAs (closes 7 code-scanning alerts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: frontend/coverage/lcov.info
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: frontend/test-report.junit.xml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,13 +29,13 @@ jobs:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: "projects/${{ vars.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/${{ vars.WIF_POOL }}/providers/${{ vars.WIF_PROVIDER }}"
           service_account: "${{ vars.GCP_SERVICE_ACCOUNT }}"
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
@@ -61,7 +61,7 @@ jobs:
 
       - name: Deploy to Cloud Run
         id: deploy
-        uses: google-github-actions/deploy-cloudrun@v3
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
           service: portfolio-frontend
           region: us-central1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Create release PR or publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
         with:
           title: "release: version packages"
           commit: "release: version packages"

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run ZAP baseline scan
-        uses: zaproxy/action-baseline@v0.15.0
+        uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
           target: ${{ github.event.inputs.target || 'https://seanbearden.com' }}
           docker_name: "ghcr.io/zaproxy/zaproxy:stable"


### PR DESCRIPTION
## Why
GitHub code scanning is flagging 7 \`actions/unpinned-tag\` warnings on \`main\`. Tag refs like \`@v5\`, \`@v3\` can be retroactively re-pointed by the action's maintainer or in a supply-chain compromise; SHA pins ensure the exact code that ran yesterday runs today. This is the standard hardening per [GitHub's security guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## What
Resolved each tag to its current commit SHA via \`gh api repos/<owner>/<repo>/commits/<tag>\` and pinned, keeping a version comment so humans (and Dependabot) can read intent at a glance:

| Action | SHA | Tag |
|---|---|---|
| \`zaproxy/action-baseline\` | \`de8ad96\` | v0.15.0 |
| \`codecov/codecov-action\` (×2) | \`75cd116\` | v5 |
| \`google-github-actions/auth\` | \`7c6bc77\` | v3 |
| \`google-github-actions/setup-gcloud\` | \`aa5489c\` | v3 |
| \`google-github-actions/deploy-cloudrun\` | \`2028e2d\` | v3 |
| \`changesets/action\` | \`6a0a831\` | v1 |

First-party actions (\`actions/checkout\`, \`actions/setup-node\`, \`github/codeql-action\`) intentionally left tag-pinned — maintained by GitHub and exempt from the rule.

## Maintenance
[\`.github/dependabot.yml\`](https://github.com/seanbearden/portfolio/blob/main/.github/dependabot.yml) already has \`package-ecosystem: github-actions\` configured with weekly updates. The version comments next to each SHA pin make the Dependabot PRs readable; it'll bump both the SHA and the comment together.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, the 7 code-scanning alerts close automatically (CodeQL re-runs Mondays + on push)
- [ ] Dependabot's next weekly run produces clean update PRs (verify when one comes through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)