### PR TITLE
ci(security): point ZAP + Observatory at Cloud Run pre-cutover

### DIFF
--- a/.github/workflows/security-headers.yml
+++ b/.github/workflows/security-headers.yml
@@ -6,9 +6,10 @@ on:
   workflow_dispatch:
     inputs:
       host:
-        description: "Hostname (no scheme) to scan"
+        # TODO: flip default to seanbearden.com after Squarespace DNS cutover
+        description: "Hostname (no scheme; default = Cloud Run revision; pre-cutover seanbearden.com still serves Squarespace)"
         required: false
-        default: "seanbearden.com"
+        default: "portfolio-frontend-pr4cby3raa-uc.a.run.app"
       min_grade:
         description: "Minimum acceptable Mozilla Observatory grade"
         required: false
@@ -23,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      HOST: ${{ github.event.inputs.host || 'seanbearden.com' }}
+      HOST: ${{ github.event.inputs.host || 'portfolio-frontend-pr4cby3raa-uc.a.run.app' }}
       MIN_GRADE: ${{ github.event.inputs.min_grade || 'B' }}
     steps:
       - name: Trigger and read scan

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -9,9 +9,10 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: "URL to scan"
+        # TODO: flip default to https://seanbearden.com after Squarespace DNS cutover
+        description: "URL to scan (default = Cloud Run revision; pre-cutover seanbearden.com still serves Squarespace)"
         required: false
-        default: "https://seanbearden.com"
+        default: "https://portfolio-frontend-pr4cby3raa-uc.a.run.app"
 
 permissions:
   contents: read
@@ -29,7 +30,7 @@ jobs:
       - name: Run ZAP baseline scan
         uses: zaproxy/action-baseline@v0.15.0
         with:
-          target: ${{ github.event.inputs.target || 'https://seanbearden.com' }}
+          target: ${{ github.event.inputs.target || 'https://portfolio-frontend-pr4cby3raa-uc.a.run.app' }}
           docker_name: "ghcr.io/zaproxy/zaproxy:stable"
           rules_file_name: ".zap/rules.tsv"
           cmd_options: "-a"


### PR DESCRIPTION
## Why
\`seanbearden.com\` still resolves to Squarespace until DNS cutover (verified: \`server: Squarespace\` in response headers). Scanning that URL audits infra we don't control. Both ZAP and Observatory should hit the actual Cloud Run revision so scans exercise the nginx config + headers we ship.

I confirmed the Cloud Run URL responds (\`HTTP 200\`, \`server: Google Frontend\`), and notably ships zero security headers right now — the revision serving is from April 5th, predates the nginx hardening in #93. Once a release tag triggers a redeploy, ZAP will pick up the new state via the \`workflow_run\` trigger from #94.

## What
- ZAP \`target\` default: \`https://seanbearden.com\` → \`https://portfolio-frontend-pr4cby3raa-uc.a.run.app\`
- Observatory \`host\` default: \`seanbearden.com\` → \`portfolio-frontend-pr4cby3raa-uc.a.run.app\`
- TODO comments next to each default flag the post-cutover flip back

\`workflow_dispatch\` overrides remain available — easy to point at any host on demand.

## Test plan
- [ ] Manual dispatch on this branch's workflows succeeds against the Cloud Run URL
- [ ] After merge + the next release tag → ZAP fires via \`workflow_run\`, scans the freshly-deployed revision, and the auto-issue reflects what we actually shipped
- [ ] After Squarespace cutover, flip both defaults back per the TODO comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)