### PR TITLE
ci(release): auto-push tag and dispatch Deploy on release runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write   # to dispatch Deploy after a release tag is pushed
     steps:
       - uses: actions/checkout@v6
 
@@ -34,6 +35,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push tags
-        if: steps.changesets.outputs.published == 'true'
-        run: git push --follow-tags
+      # The changesets/action `published` output is only set when the publish
+      # command is detected as an npm publish. We use it for git tagging via
+      # tag-version.js, so the output stays false. Detect a release run by
+      # checking whether tag-version.js created a local tag, then push it and
+      # dispatch Deploy explicitly (tag pushes via GITHUB_TOKEN don't trigger
+      # downstream workflows on their own).
+      - name: Push release tag and dispatch Deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+          if git rev-parse --verify --quiet "refs/tags/$TAG" > /dev/null; then
+            echo "Pushing $TAG and dispatching Deploy"
+            git push origin "$TAG"
+            gh workflow run deploy.yml --ref "$TAG"
+          else
+            echo "No release tag this run (version PR opened/updated, or nothing to release)"
+          fi


### PR DESCRIPTION
## Why
The previous \`Push tags\` step was gated on \`steps.changesets.outputs.published == 'true'\`. The \`changesets/action\` only sets that to \`true\` when it detects a successful npm publish from the publish command's output. We use the publish command for **git tagging via \`scripts/tag-version.js\`**, not npm publishing — so the output stays \`false\` and the tag is never pushed.

That's why **v0.3.0 sat unreleased on the runner** when the user merged PR #10. It only got deployed because I manually ran \`git push origin v0.3.0\` afterward.

Compounding factor: even if we did push the tag, **GITHUB_TOKEN-authored tag pushes don't trigger downstream workflows** (GitHub's anti-loop guard). So \`Deploy\`'s \`push: tags: [\"v*\"]\` trigger wouldn't fire either.

## What
Replace the gated push with a self-detecting step:

\`\`\`yaml
- name: Push release tag and dispatch Deploy
  env:
    GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
  run: |
    VERSION=\$(node -p \"require('./package.json').version\")
    TAG=\"v\$VERSION\"
    if git rev-parse --verify --quiet \"refs/tags/\$TAG\" > /dev/null; then
      git push origin \"\$TAG\"
      gh workflow run deploy.yml --ref \"\$TAG\"
    fi
\`\`\`

- The local tag exists *only* when \`tag-version.js\` ran in publish mode (post-version-PR-merge runs). Version-PR-creation runs don't create a local tag, so this no-ops cleanly.
- \`gh workflow run deploy.yml --ref \"\$TAG\"\` dispatches Deploy explicitly. \`workflow_dispatch\` events DO run on \`GITHUB_TOKEN\`, sidestepping the anti-loop guard.
- Adds \`actions: write\` permission so the dispatch call is allowed.

## After this
Future flow:
1. PRs merged → release.yml opens/updates a \`release: version packages\` PR (#10-style)
2. Merge that PR → release.yml runs publish → \`tag-version.js\` creates the tag → this step pushes it + dispatches Deploy
3. Deploy builds and ships
4. ZAP fires via \`workflow_run\` (per #94)
5. No manual intervention needed

## Test plan
- [ ] CI passes on this PR
- [ ] On the next \`release: version packages\` PR merge, observe: tag pushed to origin, Deploy run starts automatically with \`event: workflow_dispatch\` and \`ref: v\$VERSION\`
- [ ] Existing \`gh workflow run deploy --field ref=...\` manual override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)