### PR TITLE
fix(release): skip tag push when remote already has the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,13 @@ jobs:
       # The changesets/action `published` output is only set when the publish
       # command is detected as an npm publish. We use it for git tagging via
       # tag-version.js, so the output stays false. Detect a release run by
-      # checking whether tag-version.js created a local tag, then push it and
-      # dispatch Deploy explicitly (tag pushes via GITHUB_TOKEN don't trigger
-      # downstream workflows on their own).
+      # checking whether tag-version.js created a local tag that's NOT yet on
+      # the remote, then push it and dispatch Deploy explicitly (tag pushes
+      # via GITHUB_TOKEN don't trigger downstream workflows on their own).
+      #
+      # tag-version.js runs on every release invocation when no changesets are
+      # pending — including subsequent main pushes after the version PR has
+      # already been published. The remote-existence check makes those runs no-ops.
       - name: Push release tag and dispatch Deploy
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,10 +52,17 @@ jobs:
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
           TAG="v$VERSION"
-          if git rev-parse --verify --quiet "refs/tags/$TAG" > /dev/null; then
-            echo "Pushing $TAG and dispatching Deploy"
-            git push origin "$TAG"
-            gh workflow run deploy.yml --ref "$TAG"
-          else
+
+          if ! git rev-parse --verify --quiet "refs/tags/$TAG" > /dev/null; then
             echo "No release tag this run (version PR opened/updated, or nothing to release)"
+            exit 0
           fi
+
+          if git ls-remote --tags --exit-code origin "refs/tags/$TAG" > /dev/null 2>&1; then
+            echo "Remote already has $TAG; nothing to publish"
+            exit 0
+          fi
+
+          echo "Pushing $TAG and dispatching Deploy"
+          git push origin "$TAG"
+          gh workflow run deploy.yml --ref "$TAG"


### PR DESCRIPTION
## Summary

PR #101 added an explicit tag-push + Deploy dispatch step, but assumed `tag-version.js` only creates a local tag on a fresh release. In practice `changesets/action` runs `publish` on **every** main push when no changesets are pending — so `tag-version.js` re-creates `v<current-version>` locally on every subsequent run, and the workflow tries to push an already-existing remote tag.

That's exactly what failed on the run right after #101 merged:

\`\`\`
Pushing v0.3.0 and dispatching Deploy
 ! [rejected]        v0.3.0 -> v0.3.0 (already exists)
error: failed to push some refs
\`\`\`

## Fix

Add a `git ls-remote --tags --exit-code origin "refs/tags/$TAG"` check before pushing. When the remote already has the tag, exit cleanly. The Release run becomes a no-op, no spurious Deploy dispatch, no red CI.

This preserves the desired behavior:
- **Version PR merge** → `tag-version.js` creates new tag locally → remote doesn't have it yet → push + dispatch Deploy ✅
- **Any other main push** → `tag-version.js` re-creates existing tag locally → remote has it → skip silently ✅

## Test plan

- [x] Manual logic walkthrough against the failing run output (`run 25264202601`)
- [ ] After merge: confirm next non-version main push triggers a Release run that **succeeds** with the "Remote already has vX.Y.Z" log line
- [ ] At next version PR merge: confirm Release pushes the new tag and dispatches Deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)