### PR TITLE
docs(nginx): document CSP style-src 'unsafe-inline' rationale

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -12,6 +12,11 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;
+    # CSP: style-src 'unsafe-inline' is required because framer-motion injects inline
+    # style attributes for animations (transform/opacity). We accept this trade-off and
+    # let ZAP rule 10055-6 keep firing as an audit trail. Do NOT silence rule 10055 —
+    # it also covers script-src 'unsafe-inline' (10055-5) and 'unsafe-eval' (10055-10),
+    # which we DO want to be alerted on.
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header Cross-Origin-Embedder-Policy "unsafe-none" always;
@@ -39,6 +44,11 @@ server {
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;
+        # CSP: style-src 'unsafe-inline' is required because framer-motion injects inline
+        # style attributes for animations (transform/opacity). We accept this trade-off and
+        # let ZAP rule 10055-6 keep firing as an audit trail. Do NOT silence rule 10055 —
+        # it also covers script-src 'unsafe-inline' (10055-5) and 'unsafe-eval' (10055-10),
+        # which we DO want to be alerted on.
         add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Cross-Origin-Embedder-Policy "unsafe-none" always;


### PR DESCRIPTION
## Summary

framer-motion injects inline style attributes for animation transforms/opacity, so `style-src 'unsafe-inline'` is genuinely required. This PR adds a comment block above each of the two CSP `add_header` lines (server-level + static-asset `location`) explaining the trade-off and warning maintainers **not** to silence ZAP rule 10055.

## What changed vs the original PR

The original PR added `10055 IGNORE` to `.zap/rules.tsv`. Per [the ZAP docs](https://www.zaproxy.org/docs/alerts/10055/), rule 10055 is a single rule ID covering **13 distinct CSP sub-checks**, including:

- `10055-5`: `script-src 'unsafe-inline'`
- `10055-10`: `script-src 'unsafe-eval'`
- `10055-13`: undefined directive with no fallback

Suppressing 10055 to silence the `style-src` warning would mask all 12 other sub-checks — including the two critical `script-src` ones our CSP is designed to prevent. The rules.tsv parser doesn't support targeting individual sub-alerts ([source: `zap_common.py`](https://github.com/zaproxy/zaproxy/blob/main/docker/zap_common.py)).

This revision drops:
- ❌ `.zap/rules.tsv` IGNORE entry (would mask script-src regressions)
- ❌ `.changeset/puny-facts-accept.md` (no shipped runtime change; comment-only nginx diff)

…and keeps:
- ✅ The nginx comments — expanded to explicitly call out the regression risk

## Why no changeset

The PR is now comment-only. nginx serves the same response headers before and after this PR. No user-visible change → nothing for release notes to describe.

## Test plan

- [x] `cd frontend && npm run build` — passes
- [x] `git diff` shows comment-only nginx changes (10 added lines, 0 removed)
- [x] No `.zap/rules.tsv` change → ZAP rule 10055 still fires on every scan as audit trail
- [ ] After merge: confirm next scheduled ZAP scan still reports the `style-src 'unsafe-inline'` warning (which is the intended outcome, not a failure)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)