### PR TITLE
harden(nginx): tune Cache-Control for HTML vs immutable assets

### DIFF
--- a/.changeset/harden-nginx-cache.md
+++ b/.changeset/harden-nginx-cache.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Cache HTML as no-cache and hashed assets as immutable.

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -6,7 +6,7 @@ server {
 
     # --- Security headers ---
     # nginx add_header does not inherit when a child block uses add_header,
-    # so server-level headers are also redeclared in the static-asset location below.
+    # so server-level headers are also redeclared in the location blocks below.
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
@@ -26,14 +26,10 @@ server {
     #     proxy_set_header X-Forwarded-Proto $scheme;
     # }
 
-    # SPA fallback
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-
-    # Cache static assets
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?|webp)$ {
-        expires 1y;
+    # 1. HTML — no-cache so deploys are picked up immediately
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        # security headers
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;
@@ -43,6 +39,53 @@ server {
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Cross-Origin-Embedder-Policy "unsafe-none" always;
         add_header Cross-Origin-Resource-Policy "same-origin" always;
-        add_header Cache-Control "public, immutable" always;
+    }
+
+    # Default for SPA routes (also serves index.html via try_files)
+    location / {
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache" always;
+        # security headers
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "unsafe-none" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+    }
+
+    # 2. Hashed assets — immutable, 1-year cache
+    location ~* ^/assets/.+\.(js|css|woff2?|png|jpg|jpeg|svg|webp|avif)$ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        # security headers
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "unsafe-none" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
+    }
+
+    # 3. Non-hashed static files (favicon.svg, robots.txt, sitemap.xml)
+    location ~* \.(ico|svg|txt|xml)$ {
+        expires 1h;
+        add_header Cache-Control "public, max-age=3600" always;
+        # security headers
+        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "unsafe-none" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
     }
 }


### PR DESCRIPTION
This PR updates the Nginx configuration to differentiate between the HTML entry point and hashed assets produced by Vite. It ensures that the HTML shell is always revalidated (allowing for immediate deployment updates) while hashed assets are cached long-term for performance. It also adds a short-term cache for non-hashed static files in the root.

Key changes:
- Added `location = /index.html` with strict no-cache headers.
- Updated `location /` to use `no-cache`.
- Added regex-based location for hashed assets in `/assets/` with `immutable` caching.
- Added regex-based location for unhashed static files with 1-hour cache.
- Redeclared all security headers (HSTS, CSP, etc.) in each new location block to prevent inheritance issues.

A changeset has been included.

Fixes #105

---
*PR created automatically by Jules for task [10694047581193460077](https://jules.google.com/task/10694047581193460077) started by @seanbearden*