### PR TITLE
security: triage ZAP rule 10009 (In Page Banner Information Leak)

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -14,5 +14,9 @@
 10110	OUTOFSCOPE	.*/assets/.*
 
 # Global IGNOREs:
+# Server header is set by Google Frontend (Cloud Run's edge proxy), not our nginx.
+# Cannot be suppressed from the container side. "Google Frontend" is what GFE
+# emits regardless of upstream config.
+10009	IGNORE		Server: Google Frontend is set upstream by Cloud Run's GFE; not response-controllable.
 90005	IGNORE		Sec-Fetch-* are request headers; not response-controllable.
 10109	IGNORE		Informational alert noting that the site is an SPA.


### PR DESCRIPTION
Ignore ZAP rule 10009 (In Page Banner Information Leak) in .zap/rules.tsv. This rule flags the "Server: Google Frontend" header, which is set upstream by Cloud Run's GFE and cannot be controlled from the application. Matches are purely header-based and do not reveal sensitive version information in the response body.

Fixes #116

---
*PR created automatically by Jules for task [207916131813838569](https://jules.google.com/task/207916131813838569) started by @seanbearden*