### PR TITLE
Add tests for Button and Card UI primitives

### DIFF
--- a/.changeset/add-tests-for-button-and-card.md
+++ b/.changeset/add-tests-for-button-and-card.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Add tests for Button and Card UI primitives.

--- a/frontend/src/components/ui/button.test.tsx
+++ b/frontend/src/components/ui/button.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { createRef } from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { Button } from "./button"
+
+describe("Button", () => {
+  it("forwards ref to the button element", () => {
+    const ref = createRef<HTMLButtonElement>()
+    render(<Button ref={ref}>Ref Button</Button>)
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+    expect(ref.current).toHaveAttribute("data-slot", "button")
+  })
+
+  it("renders with default variant and size", () => {
+    render(<Button>Click me</Button>)
+    const button = screen.getByRole("button", { name: /click me/i })
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveAttribute("data-slot", "button")
+    expect(button).toHaveClass("bg-primary") // default variant
+    expect(button).toHaveClass("h-8") // default size
+  })
+
+  it("renders with all variants", () => {
+    const variants = ["default", "destructive", "outline", "secondary", "ghost", "link"] as const
+    variants.forEach((variant) => {
+      const { unmount } = render(<Button variant={variant}>{variant}</Button>)
+      const button = screen.getByRole("button", { name: variant })
+      if (variant === "default") expect(button).toHaveClass("bg-primary")
+      if (variant === "destructive") expect(button).toHaveClass("bg-destructive/10")
+      if (variant === "outline") expect(button).toHaveClass("border-border")
+      if (variant === "secondary") expect(button).toHaveClass("bg-secondary")
+      if (variant === "ghost") expect(button).toHaveClass("hover:bg-muted")
+      if (variant === "link") expect(button).toHaveClass("text-primary")
+      unmount()
+    })
+  })
+
+  it("renders with all sizes", () => {
+    const sizes = ["default", "xs", "sm", "lg", "icon", "icon-xs", "icon-sm", "icon-lg"] as const
+    sizes.forEach((size) => {
+      const { unmount } = render(<Button size={size}>{size}</Button>)
+      const button = screen.getByRole("button", { name: size })
+      if (size === "default") expect(button).toHaveClass("h-8")
+      if (size === "xs") expect(button).toHaveClass("h-6")
+      if (size === "sm") expect(button).toHaveClass("h-7")
+      if (size === "lg") expect(button).toHaveClass("h-9")
+      if (size === "icon") expect(button).toHaveClass("size-8")
+      if (size === "icon-xs") expect(button).toHaveClass("size-6")
+      if (size === "icon-sm") expect(button).toHaveClass("size-7")
+      if (size === "icon-lg") expect(button).toHaveClass("size-9")
+      unmount()
+    })
+  })
+
+  it("applies disabled prop", () => {
+    render(<Button disabled>Disabled</Button>)
+    const button = screen.getByRole("button", { name: /disabled/i })
+    expect(button).toBeDisabled()
+    expect(button).toHaveClass("disabled:opacity-50")
+  })
+
+  it("merges custom classNames", () => {
+    render(<Button className="custom-class">Custom</Button>)
+    const button = screen.getByRole("button", { name: /custom/i })
+    expect(button).toHaveClass("custom-class")
+    expect(button).toHaveClass("bg-primary")
+  })
+})

--- a/frontend/src/components/ui/card.test.tsx
+++ b/frontend/src/components/ui/card.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { createRef } from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+} from "./card"
+
+describe("Card", () => {
+  it("renders all card components correctly", () => {
+    render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+          <CardDescription>Description</CardDescription>
+          <CardAction>Action</CardAction>
+        </CardHeader>
+        <CardContent>Content</CardContent>
+        <CardFooter>Footer</CardFooter>
+      </Card>
+    )
+
+    expect(screen.getByText("Title")).toBeInTheDocument()
+    expect(screen.getByText("Description")).toBeInTheDocument()
+    expect(screen.getByText("Action")).toBeInTheDocument()
+    expect(screen.getByText("Content")).toBeInTheDocument()
+    expect(screen.getByText("Footer")).toBeInTheDocument()
+
+    expect(document.querySelector('[data-slot="card"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-slot="card-header"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-slot="card-title"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-slot="card-description"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-slot="card-action"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-slot="card-content"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-slot="card-footer"]')).toBeInTheDocument()
+  })
+
+  it("applies size props correctly", () => {
+    const { rerender } = render(<Card size="default">Default</Card>)
+    expect(document.querySelector('[data-slot="card"]')).toHaveAttribute("data-size", "default")
+
+    rerender(<Card size="sm">Small</Card>)
+    expect(document.querySelector('[data-slot="card"]')).toHaveAttribute("data-size", "sm")
+  })
+
+  it("merges custom classNames", () => {
+    render(
+      <Card className="custom-card">
+        <CardHeader className="custom-header">
+          <CardTitle className="custom-title" />
+          <CardDescription className="custom-desc" />
+          <CardAction className="custom-action" />
+        </CardHeader>
+        <CardContent className="custom-content" />
+        <CardFooter className="custom-footer" />
+      </Card>
+    )
+
+    expect(document.querySelector('[data-slot="card"]')).toHaveClass("custom-card")
+    expect(document.querySelector('[data-slot="card-header"]')).toHaveClass("custom-header")
+    expect(document.querySelector('[data-slot="card-title"]')).toHaveClass("custom-title")
+    expect(document.querySelector('[data-slot="card-description"]')).toHaveClass("custom-desc")
+    expect(document.querySelector('[data-slot="card-action"]')).toHaveClass("custom-action")
+    expect(document.querySelector('[data-slot="card-content"]')).toHaveClass("custom-content")
+    expect(document.querySelector('[data-slot="card-footer"]')).toHaveClass("custom-footer")
+  })
+
+  it("forwards refs to all components", () => {
+    const cardRef = createRef<HTMLDivElement>()
+    const headerRef = createRef<HTMLDivElement>()
+    const titleRef = createRef<HTMLDivElement>()
+    const descriptionRef = createRef<HTMLDivElement>()
+    const actionRef = createRef<HTMLDivElement>()
+    const contentRef = createRef<HTMLDivElement>()
+    const footerRef = createRef<HTMLDivElement>()
+
+    render(
+      <Card ref={cardRef}>
+        <CardHeader ref={headerRef}>
+          <CardTitle ref={titleRef} />
+          <CardDescription ref={descriptionRef} />
+          <CardAction ref={actionRef} />
+        </CardHeader>
+        <CardContent ref={contentRef} />
+        <CardFooter ref={footerRef} />
+      </Card>
+    )
+
+    expect(cardRef.current).toHaveAttribute("data-slot", "card")
+    expect(headerRef.current).toHaveAttribute("data-slot", "card-header")
+    expect(titleRef.current).toHaveAttribute("data-slot", "card-title")
+    expect(descriptionRef.current).toHaveAttribute("data-slot", "card-description")
+    expect(actionRef.current).toHaveAttribute("data-slot", "card-action")
+    expect(contentRef.current).toHaveAttribute("data-slot", "card-content")
+    expect(footerRef.current).toHaveAttribute("data-slot", "card-footer")
+  })
+})


### PR DESCRIPTION
I have added unit tests for the `Button` and `Card` UI primitives in `frontend/src/components/ui/`.

Key changes:
- `frontend/src/components/ui/button.test.tsx`: Tests all button variants (`default`, `destructive`, `outline`, `secondary`, `ghost`, `link`), all sizes, the `disabled` prop, custom `className` merging, and ref forwarding.
- `frontend/src/components/ui/card.test.tsx`: Tests all exported sub-components (`Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardAction`, `CardContent`, `CardFooter`), the `size` prop for the `Card` component, custom `className` merging, and ref forwarding for all components.
- Verified 100% statement, branch, and function coverage for both `button.tsx` and `card.tsx`.
- Added a changeset file for the patch.

The tests use `jsdom` environment and `@testing-library/react`. I used `data-slot` attributes for robust element selection where appropriate.

Fixes #120

---
*PR created automatically by Jules for task [4357929555062370766](https://jules.google.com/task/4357929555062370766) started by @seanbearden*