### PR TITLE
Add route-table coverage for App.tsx

### DIFF
--- a/.changeset/add-app-route-tests.md
+++ b/.changeset/add-app-route-tests.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Add route-table tests for App.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import App, { AppRoutes } from "./App";
+
+vi.mock("@/utils/content", () => ({
+  getHomeData: () => ({
+    hero: {
+      name: "Sean Bearden",
+      headline: "Data Scientist",
+      email: "sean@example.com",
+    },
+    social: { github: "https://github.com/test" },
+    experience: [],
+    education: [],
+    awards: [],
+    skills: {},
+    about: "This is a bio about me.",
+    bio: ["This is a bio about me."],
+    interests: ["Physics", "ML"],
+    press: [],
+  }),
+  getProjects: () => [
+    {
+      title: "Test Project",
+      subtitle: "Sub",
+      slug: "test-project",
+      body: "Test project body content.",
+      skills: ["TypeScript"],
+      link: "https://example.com",
+      cta: "View Project",
+    },
+  ],
+  getBlogPosts: () => [
+    {
+      title: "Test Post",
+      body: "Post content snippet.",
+      date: "2024-01-01",
+      slug: "test-post",
+      categories: [],
+      tags: [],
+    },
+  ],
+  getBlogPost: (slug: string) => {
+    if (slug === "test-post") {
+      return {
+        title: "Test Post",
+        body: "Full post content.",
+        date: "2024-01-01",
+        slug: "test-post",
+        categories: [],
+        tags: [],
+      };
+    }
+    return undefined;
+  },
+  getPublications: () => [
+    {
+      title: "Test Publication",
+      journal: "Test Journal",
+      year: "2024",
+      link: "https://example.com/pub",
+    },
+  ],
+  assetUrl: (f: string) => `https://cdn.example.com/${f}`,
+  pdfUrl: (f: string) => `https://cdn.example.com/pdfs/${f}`,
+}));
+
+describe("App Route Table", () => {
+  const renderAppRoutes = (initialRoute: string) =>
+    render(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <AppRoutes />
+      </MemoryRouter>
+    );
+
+  it("renders HomePage for /", () => {
+    renderAppRoutes("/");
+    expect(screen.getByRole("heading", { name: /Sean Bearden/i })).toBeInTheDocument();
+  });
+
+  it("renders AboutPage for /about", () => {
+    renderAppRoutes("/about");
+    expect(screen.getByRole("heading", { name: /^About$/i })).toBeInTheDocument();
+  });
+
+  it("renders PortfolioPage for /portfolio", () => {
+    renderAppRoutes("/portfolio");
+    expect(screen.getByRole("heading", { name: /^Portfolio$/i })).toBeInTheDocument();
+  });
+
+  it("renders BlogPage for /blog", () => {
+    renderAppRoutes("/blog");
+    expect(screen.getByRole("heading", { name: /^Blog$/i })).toBeInTheDocument();
+  });
+
+  it("renders BlogPostPage for /blog/test-post", () => {
+    renderAppRoutes("/blog/test-post");
+    expect(screen.getByRole("heading", { name: /Test Post/i })).toBeInTheDocument();
+  });
+
+  it("renders PublicationsPage for /publications", () => {
+    renderAppRoutes("/publications");
+    expect(screen.getByRole("heading", { name: /^Publications$/i })).toBeInTheDocument();
+  });
+
+  it("renders ContactPage for /contact", () => {
+    renderAppRoutes("/contact");
+    expect(screen.getByRole("heading", { name: /Get in Touch/i })).toBeInTheDocument();
+  });
+
+  it("renders NotFoundPage for unknown routes", () => {
+    renderAppRoutes("/some-random-route");
+    expect(screen.getByRole("heading", { name: /404/i })).toBeInTheDocument();
+  });
+
+  it("renders main App component without crashing", () => {
+    render(<App />);
+    expect(screen.getByRole("heading", { name: /Sean Bearden/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,21 +9,27 @@ import { PublicationsPage } from "@/pages/PublicationsPage";
 import { ContactPage } from "@/pages/ContactPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route index element={<HomePage />} />
+        <Route path="about" element={<AboutPage />} />
+        <Route path="portfolio" element={<PortfolioPage />} />
+        <Route path="blog" element={<BlogPage />} />
+        <Route path="blog/:slug" element={<BlogPostPage />} />
+        <Route path="publications" element={<PublicationsPage />} />
+        <Route path="contact" element={<ContactPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Route>
+    </Routes>
+  );
+}
+
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route index element={<HomePage />} />
-          <Route path="about" element={<AboutPage />} />
-          <Route path="portfolio" element={<PortfolioPage />} />
-          <Route path="blog" element={<BlogPage />} />
-          <Route path="blog/:slug" element={<BlogPostPage />} />
-          <Route path="publications" element={<PublicationsPage />} />
-          <Route path="contact" element={<ContactPage />} />
-          <Route path="*" element={<NotFoundPage />} />
-        </Route>
-      </Routes>
+      <AppRoutes />
     </BrowserRouter>
   );
 }


### PR DESCRIPTION
This PR adds unit tests for the route table in `App.tsx`, which previously had 0% coverage. 

Key changes:
- Refactored `frontend/src/App.tsx` to separate the `Routes` definition into an `AppRoutes` component. This allows for easier testing using `MemoryRouter`.
- Created `frontend/src/App.test.tsx` which tests all routes (Home, About, Portfolio, Blog, Blog Post, Publications, Contact, and Not Found) by asserting the presence of unique page elements.
- Achieved 100% code coverage for `App.tsx`.
- Added a changeset file to document the changes.

Verification:
- Ran `npm run test` in the `frontend` directory; all 66 tests passed.
- Ran `npm run test:coverage -- App.tsx` and confirmed 100% coverage.
- Visually verified all routes using a Playwright script and screenshots.

Fixes #119

---
*PR created automatically by Jules for task [1689546758031162315](https://jules.google.com/task/1689546758031162315) started by @seanbearden*