### PR TITLE
docs(nginx): document GFE Server header behavior and ZAP triage rationale

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -4,6 +4,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Note on the Server response header:
+    # Cloud Run terminates TLS at Google Frontend (GFE) and rewrites the Server
+    # header to 'Server: Google Frontend' regardless of what nginx emits. We
+    # don't bother with 'server_tokens off' here — it would be a no-op.
+    #
+    # ZAP rule 10009 (In Page Banner Information Leak) reports this on every
+    # scan. We accept the warning as an audit trail: if we ever migrate off
+    # Cloud Run and the new host leaks an actual version banner (e.g.
+    # 'nginx/1.27.4'), the same rule will catch it. Silencing it via
+    # .zap/rules.tsv would mask that future signal — see closed PR #122 / issue #116.
+
     # --- Security headers ---
     # nginx add_header does not inherit when a child block uses add_header,
     # so server-level headers are also redeclared in the location blocks below.


### PR DESCRIPTION
This PR adds a comment block to `frontend/nginx.conf.template` explaining that Cloud Run (via Google Frontend) rewrites the `Server` response header. It also documents why we deliberately avoid suppressing ZAP rule 10009 (In Page Banner Information Leak), treating it as an audit trail for potential future migrations. This follows the project's ZAP triage policy outlined in `AGENTS.md`.

Fixes #125

---
*PR created automatically by Jules for task [17825947916397459995](https://jules.google.com/task/17825947916397459995) started by @seanbearden*