### PR TITLE
ci(security): bump ZAP full scan timeout (60m → 180m) + internal -T 150 deadline

### DIFF
--- a/.github/workflows/zap-full-scan.yml
+++ b/.github/workflows/zap-full-scan.yml
@@ -27,7 +27,13 @@ jobs:
   full-scan:
     name: ZAP full active scan
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Two-layer timeout: ZAP itself self-terminates at -T 150 (cmd_options below)
+    # and produces a partial report cleanly. The job-level timeout-minutes is the
+    # outer safety net set 30 min higher so the runner kills only if ZAP hangs
+    # past its own deadline. Initial 60-min run (workflow run 25265466347) hit
+    # the runner cutoff while ZAP was still actively scanning — bumped to give
+    # the spider + AJAX spider + active probes room on a multi-route SPA.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v6
 
@@ -37,7 +43,10 @@ jobs:
           target: ${{ github.event.inputs.target || 'https://portfolio-frontend-pr4cby3raa-uc.a.run.app' }}
           docker_name: "ghcr.io/zaproxy/zaproxy:stable"
           rules_file_name: ".zap/rules.tsv"
-          cmd_options: "-a"
+          # -a: include alpha rules (broader coverage)
+          # -T 150: cap ZAP's total run at 150 minutes; produces a partial report
+          #         on timeout instead of getting killed mid-scan by the runner.
+          cmd_options: "-a -T 150"
           fail_action: false
           allow_issue_writing: true
           artifact_name: "zap-full-scan-report"


### PR DESCRIPTION
## Summary

The first full-scan dispatch ([run 25265466347](https://github.com/seanbearden/portfolio/actions/runs/25265466347)) hit our job-level `timeout-minutes: 60` while ZAP was still actively scanning. Spider + AJAX spider + active probes (50+ rules per discovered URL × \`-a\` alpha rules) on a multi-route SPA legitimately needs longer than an hour. The 60-minute default I set in PR #113 was a guess that turned out tight.

## Changes

Two-layer timeout strategy:

| Layer | Value | Purpose |
|---|---|---|
| `cmd_options: \"-a -T 150\"` | 150 min | ZAP's own scan deadline. On timeout, produces a partial report cleanly. |
| `timeout-minutes: 180` | 180 min | Outer GitHub Actions safety net. Only kills if ZAP hangs past its own deadline. |

The 30-min buffer between the two is for container teardown + artifact upload.

## Why both, not just one

- Bumping only `timeout-minutes` to 180 risks ZAP getting killed mid-scan by GitHub Actions with no report at 180:00.
- Setting only `-T 150` works in normal cases but doesn't protect against ZAP itself hanging (rare but real on stable Docker images).
- Two-layer means we always get a report, and we have hard upper bound on runner minutes consumed per dispatch.

## Why not reduce scope instead

Could drop \`-a\` to skip alpha rules, or add more `OUTOFSCOPE` exclusions. But:
- \`-a\` is the whole point of a *full* scan vs the baseline. Removing it makes the workflow redundant with the baseline.
- We already exclude \`/assets/*\` for the noisy bundle-content rules per PR #107.

If 180 min still isn't enough on a future scan, that's a real signal — worth investigating which rule is taking forever rather than blindly bumping again.

## Test plan

- [x] Workflow YAML diff is comments + value bumps only (no structural changes)
- [ ] After merge: dispatch (`gh workflow run zap-full-scan.yml --ref main`) and confirm the run completes within 180 min with a populated artifact
- [ ] If the run still times out, file an issue investigating which scan phase is slowest (spider vs ajax-spider vs active scan)

## Why no changeset

`.github/workflows/**` is on the AGENTS.md skip list (CI doesn't ship in the runtime bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)