### PR TITLE
ci(security): point ZAP + Observatory scans at seanbearden.com (post-cutover)

### DIFF
--- a/.github/workflows/security-headers.yml
+++ b/.github/workflows/security-headers.yml
@@ -6,10 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       host:
-        # TODO: flip default to seanbearden.com after Squarespace DNS cutover
-        description: "Hostname (no scheme; default = Cloud Run revision; pre-cutover seanbearden.com still serves Squarespace)"
+        description: "Hostname (no scheme; default = production seanbearden.com; pass a Cloud Run revision host on dispatch to scan that instead)"
         required: false
-        default: "portfolio-frontend-pr4cby3raa-uc.a.run.app"
+        default: "seanbearden.com"
       min_grade:
         description: "Minimum acceptable Mozilla Observatory grade"
         required: false
@@ -24,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      HOST: ${{ github.event.inputs.host || 'portfolio-frontend-pr4cby3raa-uc.a.run.app' }}
+      HOST: ${{ github.event.inputs.host || 'seanbearden.com' }}
       MIN_GRADE: ${{ github.event.inputs.min_grade || 'B' }}
     steps:
       - name: Trigger and read scan

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -9,10 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        # TODO: flip default to https://seanbearden.com after Squarespace DNS cutover
-        description: "URL to scan (default = Cloud Run revision; pre-cutover seanbearden.com still serves Squarespace)"
+        description: "URL to scan (default = production seanbearden.com; pass a Cloud Run revision URL on dispatch to scan that instead)"
         required: false
-        default: "https://portfolio-frontend-pr4cby3raa-uc.a.run.app"
+        default: "https://seanbearden.com"
 
 permissions:
   contents: read
@@ -30,7 +29,7 @@ jobs:
       - name: Run ZAP baseline scan
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
-          target: ${{ github.event.inputs.target || 'https://portfolio-frontend-pr4cby3raa-uc.a.run.app' }}
+          target: ${{ github.event.inputs.target || 'https://seanbearden.com' }}
           docker_name: "ghcr.io/zaproxy/zaproxy:stable"
           rules_file_name: ".zap/rules.tsv"
           cmd_options: "-a"

--- a/.github/workflows/zap-full-scan.yml
+++ b/.github/workflows/zap-full-scan.yml
@@ -14,10 +14,9 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        # TODO: flip default to https://seanbearden.com after Squarespace DNS cutover
-        description: "URL to scan (default = Cloud Run revision; pre-cutover seanbearden.com still serves Squarespace)"
+        description: "URL to scan (default = production seanbearden.com; pass a Cloud Run revision URL on dispatch to scan that instead)"
         required: false
-        default: "https://portfolio-frontend-pr4cby3raa-uc.a.run.app"
+        default: "https://seanbearden.com"
 
 permissions:
   contents: read
@@ -34,7 +33,7 @@ jobs:
       - name: Run ZAP full scan
         uses: zaproxy/action-full-scan@bee4e5be916301228d2b1b2dcad73aab6fa6a25b # v0.13.0
         with:
-          target: ${{ github.event.inputs.target || 'https://portfolio-frontend-pr4cby3raa-uc.a.run.app' }}
+          target: ${{ github.event.inputs.target || 'https://seanbearden.com' }}
           docker_name: "ghcr.io/zaproxy/zaproxy:stable"
           rules_file_name: ".zap/rules.tsv"
           cmd_options: "-a"


### PR DESCRIPTION
## Summary

DNS for seanbearden.com is now pointing at the Cloud Run service via the custom domain mapping. The Cloud Run URL and the custom domain serve **the same nginx + same content through the same GFE edge** — but `seanbearden.com` is what users actually hit, and Mozilla Observatory's checks (HSTS preload list, etc.) only make sense against the public-facing hostname.

This flips the three security scan workflows to default to `seanbearden.com`. The Cloud Run URL can still be scanned via the `workflow_dispatch` input on demand.

## Changes

| File | Default before | Default after |
|---|---|---|
| `.github/workflows/zap-baseline.yml` | `https://portfolio-frontend-pr4cby3raa-uc.a.run.app` | `https://seanbearden.com` |
| `.github/workflows/zap-full-scan.yml` | `https://portfolio-frontend-pr4cby3raa-uc.a.run.app` | `https://seanbearden.com` |
| `.github/workflows/security-headers.yml` | `portfolio-frontend-pr4cby3raa-uc.a.run.app` | `seanbearden.com` |

Also removes the `TODO: flip default to seanbearden.com after Squarespace DNS cutover` comments left over from PR #99.

## Why not scan both URLs

Both URLs hit the same Cloud Run service through the same edge:
- Same nginx config (`server_name _;` catches all hosts)
- Same response headers (CSP, HSTS, COOP/CORP, etc.)
- Same content
- Different TLS cert (Cloud Run wildcard vs Let's Encrypt) — but ZAP/Observatory check policy, not which CA signed it

A scan of the Cloud Run URL adds ~zero unique signal vs a scan of `seanbearden.com`. We have no domain-specific code branches (verified — `grep -r host frontend/src` returns no matches in routing logic). Scanning both would just double runner-minute cost without finding anything different.

## Manual override preserved

The `workflow_dispatch` `target` (or `host`) input lets you still scan the Cloud Run URL on demand:

```bash
gh workflow run zap-baseline.yml \
  --field target=https://portfolio-frontend-pr4cby3raa-uc.a.run.app
```

## Test plan

- [x] Diff is target-URL-only (no logic changes)
- [ ] After merge: dispatch the baseline scan and confirm it now scans `seanbearden.com`
- [ ] Run security-headers workflow and confirm Mozilla Observatory grade against the real domain (HSTS preload eligibility may change the grade)
- [ ] Confirm `workflow_dispatch` input still accepts a custom URL (set during run, scan that instead)

## Why no changeset

`.github/workflows/**` is on the AGENTS.md skip list (CI doesn't ship in the runtime bundle).

## Don't merge until

The cert on `seanbearden.com` actually provisions and `curl -I https://seanbearden.com` returns 200. Otherwise the next scheduled scan will run against a non-functional URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)