### PR TITLE
Extend page component branch coverage

### DIFF
--- a/.changeset/extend-page-coverage.md
+++ b/.changeset/extend-page-coverage.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Extend page component branch coverage.

--- a/frontend/src/pages/BlogPostPage.test.tsx
+++ b/frontend/src/pages/BlogPostPage.test.tsx
@@ -62,4 +62,17 @@ describe("BlogPostPage", () => {
     expect(screen.getByText("Blog Index Page")).toBeInTheDocument();
     expect(screen.queryByText("Test Blog Post")).not.toBeInTheDocument();
   });
+
+  it("redirects when no slug param is present", () => {
+    render(
+      <MemoryRouter initialEntries={["/test-no-slug"]}>
+        <Routes>
+          <Route path="/test-no-slug" element={<BlogPostPage />} />
+          <Route path="/blog" element={<div>Blog Index Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Blog Index Page")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -2,6 +2,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import * as FramerMotion from "framer-motion";
+
+vi.mock("framer-motion", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("framer-motion")>();
+  return {
+    ...actual,
+    useReducedMotion: vi.fn(() => false),
+  };
+});
 
 vi.mock("@/utils/content", () => ({
   getHomeData: () => ({
@@ -45,9 +54,14 @@ vi.mock("@/utils/content", () => ({
   pdfUrl: (f: string) => `https://cdn.example.com/pdfs/${f}`,
 }));
 
+import { HomePage } from "./HomePage";
+
 describe("HomePage", () => {
+  beforeEach(() => {
+    vi.mocked(FramerMotion.useReducedMotion).mockReturnValue(false);
+  });
+
   it("renders the name and headline from home data", async () => {
-    const { HomePage } = await import("./HomePage");
     render(
       <MemoryRouter>
         <HomePage />
@@ -60,26 +74,14 @@ describe("HomePage", () => {
 
 describe("HomePage with reduced motion", () => {
   beforeEach(() => {
-    vi.stubGlobal("matchMedia", (query: string) => ({
-      matches: query.includes("prefers-reduced-motion: reduce"),
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
+    vi.mocked(FramerMotion.useReducedMotion).mockReturnValue(true);
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     cleanup();
   });
 
   it("renders correctly when prefers-reduced-motion is set", async () => {
-    vi.resetModules();
-    const { HomePage } = await import("./HomePage");
     render(
       <MemoryRouter>
         <HomePage />
@@ -88,5 +90,6 @@ describe("HomePage with reduced motion", () => {
 
     expect(screen.getByRole("heading", { name: /Sean Bearden/i })).toBeInTheDocument();
     expect(screen.getByText("Test Project")).toBeInTheDocument();
+    expect(screen.getByText("Test Post")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/PublicationsPage.test.tsx
+++ b/frontend/src/pages/PublicationsPage.test.tsx
@@ -11,6 +11,7 @@ vi.mock("@/utils/content", () => ({
       year: "2024",
       link: "https://example.com/pub",
       type: "Journal Article",
+      preprint: "https://example.com/preprint",
     },
   ],
 }));
@@ -22,5 +23,7 @@ describe("PublicationsPage", () => {
     expect(screen.getByText(/Test Journal/i)).toBeInTheDocument();
     expect(screen.getByText(/2024/i)).toBeInTheDocument();
     expect(screen.getByText(/Journal Article/i)).toBeInTheDocument();
+    expect(screen.getByText("Preprint")).toBeInTheDocument();
+    expect(screen.getByText("Preprint")).toHaveAttribute("href", "https://example.com/preprint");
   });
 });


### PR DESCRIPTION
This PR extends branch coverage for `HomePage`, `PublicationsPage`, and `BlogPostPage` to 100%.

Key changes:
1.  **BlogPostPage**: Added a test to verify the redirect when the `slug` parameter is missing.
2.  **PublicationsPage**: Updated the mock data to include a `preprint` field and verified its rendering.
3.  **HomePage**: Replaced the flawed `matchMedia` stubbing with a direct `vi.mock("framer-motion")` for the `useReducedMotion` hook. This ensures that accessibility branches (conditional variants and hover effects) are correctly exercised in tests.
4.  **Consistency**: Verified that other components using `useReducedMotion` (Header, PortfolioPage) already follow the correct mocking pattern or rely on the global setup without breaking.

A changeset has been included as requested.

Fixes #134

---
*PR created automatically by Jules for task [5891666768403558907](https://jules.google.com/task/5891666768403558907) started by @seanbearden*