### PR TITLE
Fix quoted URLs in frontmatter fallback parser

### DIFF
--- a/.changeset/harden-frontmatter-parsing.md
+++ b/.changeset/harden-frontmatter-parsing.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Harden frontmatter parsing by stripping surrounding quotes in the fallback parser to prevent malformed URLs.

--- a/frontend/src/utils/parseFrontmatter.test.ts
+++ b/frontend/src/utils/parseFrontmatter.test.ts
@@ -47,4 +47,22 @@ describe("parseFrontmatter", () => {
       body: "body",
     });
   });
+
+  it("strips quotes in fallback parser when gray-matter fails", () => {
+    // Malformed YAML (e.g., unclosed bracket) to trigger fallback
+    const malformed = `---
+title: "Quoted Title"
+link: 'https://example.com'
+tags: [malformed
+---
+body`;
+    expect(parseFrontmatter(malformed)).toEqual({
+      meta: {
+        title: "Quoted Title",
+        link: "https://example.com",
+        tags: "[malformed",
+      },
+      body: "body",
+    });
+  });
 });

--- a/frontend/src/utils/parseFrontmatter.ts
+++ b/frontend/src/utils/parseFrontmatter.ts
@@ -45,6 +45,15 @@ export function parseFrontmatter(raw: string): { meta: Record<string, string | s
       if (idx === -1) continue;
       const key = line.slice(0, idx).trim();
       let val = line.slice(idx + 1).trim();
+
+      // Strip matching surrounding double or single quotes
+      if (
+        (val.startsWith('"') && val.endsWith('"')) ||
+        (val.startsWith("'") && val.endsWith("'"))
+      ) {
+        val = val.slice(1, -1);
+      }
+
       meta[key] = val;
     }
     return { meta, body: match[2].trim() };


### PR DESCRIPTION
The reported bug where the "Chat with My Resume" link (and potentially others) might be rendered with surrounding quotes was likely due to the application's fallback frontmatter parser not stripping quotes from metadata values. This happens if the primary parser (`gray-matter`) fails on a malformed file.

This change:
1. Updates `frontend/src/utils/parseFrontmatter.ts` to strip matching surrounding single or double quotes from values in the fallback path.
2. Adds a regression test in `frontend/src/utils/parseFrontmatter.test.ts` to verify the fix.
3. Includes a changeset to document the fix.

Fixes #137

---
*PR created automatically by Jules for task [12242680595650211876](https://jules.google.com/task/12242680595650211876) started by @seanbearden*