### PR TITLE
docs: update README + AGENTS for completed Squarespace cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ content/publications.json  → direct JSON import → Publication[]
 content/home.json          → direct JSON import → HomeData
 ```
 
-All glob imports are **eager** — content is bundled into the JS, not lazy-loaded. The frontmatter parser lives in `frontend/src/utils/parseFrontmatter.ts` (custom regex-based, not `gray-matter`).
+All glob imports are **eager** — content is bundled into the JS, not lazy-loaded. The frontmatter parser lives in `frontend/src/utils/parseFrontmatter.ts`. As of PR #80 it's a thin wrapper around `gray-matter` (proper YAML parsing, including quote stripping); a regex fallback in the catch block handles cases where gray-matter throws. Don't add per-key string transforms in the wrapper — gray-matter does it correctly.
 
 Images and PDFs are **not** bundled. They live in a GCS bucket (`seanbearden-assets`). Content references assets by filename only; `assetUrl()` and `pdfUrl()` in `content.ts` prepend the `VITE_ASSETS_BASE_URL` env var.
 
@@ -106,7 +106,7 @@ Managed by Terraform in `infrastructure/`. Project: `bearden-portfolio`, region:
 - **Cloud Storage** (`seanbearden-assets`): public bucket for images and PDFs
 - **Artifact Registry** (`portfolio`): Docker images, keeps 5 recent
 - **Workload Identity Federation**: GitHub Actions authenticates to GCP via OIDC (no static keys)
-- **Domain mapping** not in Terraform — configured via `gcloud run domain-mappings create`
+- **Domain mappings** not in Terraform — created out-of-band via `gcloud beta run domain-mappings create`. Three mappings live: `seanbearden.com` (apex, A/AAAA records), `www.seanbearden.com` (CNAME → `ghs.googlehosted.com`), and `beta.seanbearden.com` (CNAME, used as a staging URL during the Squarespace cutover and kept for future dry-runs). All use Google Trust Services certs.
 
 ### Old URL Redirects
 
@@ -114,8 +114,8 @@ Managed by Terraform in `infrastructure/`. Project: `bearden-portfolio`, region:
 
 ### Phases
 
-- **Phase 1** (current): Static portfolio site on Cloud Run
-- **Phase 2** (planned): AI resume chatbot — Python FastAPI on second Cloud Run service, proxied via nginx `/api/` block (already stubbed in `nginx.conf.template`)
+- **Phase 1** (live, as of 2026-05-03): Static portfolio site on Cloud Run, served at `seanbearden.com` and `www.seanbearden.com`
+- **Phase 2** (planned): AI resume chatbot — Python FastAPI on second Cloud Run service, proxied via nginx `/api/` block (already stubbed in `nginx.conf.template`). Currently lives at `bearden-resume-chatbot.com` on Heroku.
 - **Phase 3** (planned): Interactive data playground
 
 ## Key Files
@@ -178,3 +178,5 @@ PRs that add `IGNORE` without these get rejected and re-opened with the right sc
 - **Duplicate work**: Before starting, check open PRs for the same task. PRs #16, #21, #25, #26, #27 were all closed as duplicates of already-merged work. Cross-reference issue numbers and recent merges.
 - **Stale refactors**: If you edit a function, verify it still lives in the file your branch targets. `parseFrontmatter` was extracted to `frontend/src/utils/parseFrontmatter.ts` in #30 — branches editing the old `content.ts` location won't merge.
 - **Missing changesets**: PRs #15, #17, #18, #20, #22, #28, #29, #30, #33 all merged without changesets and had to be backfilled in #34. Don't repeat this — the changeset belongs in the same PR as the code.
+- **Apex domain cert provisioning is slow vs CNAME**: Cloud Run domain mapping cert provisioning typically takes ~10-20 min for CNAME-based subdomains (`www`, `beta` → `ghs.googlehosted.com`) but can take **up to several hours** for the apex (A/AAAA records → Google's anycast IPs). Validation goes through a different path. If the apex is stuck in `CertificatePending` with "challenge data was not visible through the public internet": **don't recreate repeatedly** — that doesn't help and may worsen things by burning retry attempts. Wait through the full DNS-cache TTL window from any prior records (4 hours in the Squarespace case). Re-creates *can* clear genuinely wedged state but only after waiting a reasonable interval first.
+- **Long DNS TTLs make cutovers slow**: When migrating from another provider, the **old TTL** dictates worst-case propagation, not the new one. Squarespace's preset records had 4-hour TTL we couldn't lower in advance; cutover took ~3 hours for global propagation. Future migrations: lower TTL on the old records *first*, wait the old TTL window to expire, *then* change records.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![codecov](https://codecov.io/gh/seanbearden/portfolio/graph/badge.svg?token=JgoqNrfl9G)](https://codecov.io/gh/seanbearden/portfolio)
 
+Live at **[seanbearden.com](https://seanbearden.com)** — also serving on `www.seanbearden.com`.
+
 Personal portfolio website for Sean Bearden, Ph.D. — self-hosted on Google Cloud, migrated from Squarespace.
 
 ## Architecture
@@ -22,7 +24,7 @@ The inner ring is `frontend/`; outer rings are subdirectories and files. Color =
 
 | Phase | Description | Status |
 |-------|-------------|--------|
-| **1. Portfolio Site** | Static site with blog, portfolio, publications, about | In progress |
+| **1. Portfolio Site** | Static site with blog, portfolio, publications, about | Live |
 | **2. Resume Chatbot** | "Talk to my resume" powered by Claude/Gemini | Planned |
 | **3. Data Playground** | Upload data → instant analysis, dashboards, ML demos | Planned |
 
@@ -67,5 +69,6 @@ site-data/                # Original Squarespace extraction (reference)
 
 ## Migration Notes
 
-- Resume chatbot (bearden-resume-chatbot.com) migrating to this app in Phase 2
-- Old Squarespace URLs redirect automatically via React Router
+- DNS cutover from Squarespace to Cloud Run completed 2026-05-03. Apex (`seanbearden.com`), `www`, and a `beta` staging subdomain all serve from the same Cloud Run service via Google-managed certs.
+- Resume chatbot (`bearden-resume-chatbot.com`, on Heroku) migrating to this app in Phase 2.
+- Old Squarespace URLs redirect automatically via React Router (`frontend/src/utils/redirects.ts`).


### PR DESCRIPTION
## Summary

DNS cutover from Squarespace to Cloud Run completed today (2026-05-03). All three hostnames live with Google Trust Services certs:

- `seanbearden.com` (apex, A/AAAA)
- `www.seanbearden.com` (CNAME → `ghs.googlehosted.com`)
- `beta.seanbearden.com` (CNAME, kept for future staging dry-runs)

This PR brings the docs up to date.

## Changes

### README.md
- Add live URL line at the top
- Phase 1 status: **In progress → Live**
- Migration notes replaced with concrete cutover details + redirects file pointer

### AGENTS.md
- **Fix a real stale description**: line 77 said `parseFrontmatter` is \"custom regex-based, not gray-matter.\" It's been a gray-matter wrapper since #80 — the regex bit is just the catch-block fallback. Surfaced during my investigation of issue #137 when I temporarily suspected the parser was leaking quotes (it isn't).
- Domain mappings section: enumerate the three live mappings instead of a generic \"configured via gcloud\" line
- Phases: mark Phase 1 live with cutover date; clarify Phase 2 currently runs at `bearden-resume-chatbot.com` on Heroku
- \"Things that have caused problems\": two new entries from today's cutover
  - Apex cert provisioning is significantly slower than CNAME-based mappings (took ~3 hours vs ~20 min for `www`); don't repeatedly recreate the mapping when stuck in `CertificatePending`
  - Long old-provider TTLs dictate cutover speed; lower TTL on old records first when planning future migrations

## Why no changeset

Both files are documentation. AGENTS.md skip list explicitly covers `*.md documentation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)