### PR TITLE
Auto-generate YouTube thumbnails for portfolio cards

### DIFF
--- a/.changeset/auto-youtube-thumbnails.md
+++ b/.changeset/auto-youtube-thumbnails.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Auto-generate YouTube thumbnails for portfolio cards.

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -28,7 +28,7 @@ server {
     # let ZAP rule 10055-6 keep firing as an audit trail. Do NOT silence rule 10055 —
     # it also covers script-src 'unsafe-inline' (10055-5) and 'unsafe-eval' (10055-10),
     # which we DO want to be alerted on.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com https://img.youtube.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     # COEP: 'unsafe-none' is the deliberate value (default-permissive). Tightening to
     # 'require-corp' would block GCS-hosted images and any other cross-origin asset
@@ -57,7 +57,7 @@ server {
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com https://img.youtube.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Cross-Origin-Embedder-Policy "unsafe-none" always;
         add_header Cross-Origin-Resource-Policy "same-origin" always;
@@ -74,7 +74,7 @@ server {
         add_header X-Frame-Options "DENY" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://storage.googleapis.com https://img.youtube.com; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Cross-Origin-Embedder-Policy "unsafe-none" always;
         add_header Cross-Origin-Resource-Policy "same-origin" always;

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -5,6 +5,8 @@ import { MemoryRouter } from "react-router";
 import App, { AppRoutes } from "./App";
 
 vi.mock("@/utils/content", () => ({
+  extractYouTubeId: () => null,
+  youtubeThumbnail: (id: string) => `https://img.youtube.com/vi/${id}/maxresdefault.jpg`,
   getHomeData: () => ({
     hero: {
       name: "Sean Bearden",

--- a/frontend/src/pages/AboutPage.test.tsx
+++ b/frontend/src/pages/AboutPage.test.tsx
@@ -4,6 +4,8 @@ import { render, screen } from "@testing-library/react";
 import { AboutPage } from "./AboutPage";
 
 vi.mock("@/utils/content", () => ({
+  extractYouTubeId: () => null,
+  youtubeThumbnail: (id: string) => `https://img.youtube.com/vi/${id}/maxresdefault.jpg`,
   getHomeData: () => ({
     bio: ["Paragraph one.", "Paragraph two."],
     experience: [

--- a/frontend/src/pages/BlogPage.test.tsx
+++ b/frontend/src/pages/BlogPage.test.tsx
@@ -5,6 +5,8 @@ import { MemoryRouter } from "react-router";
 import { BlogPage } from "./BlogPage";
 
 vi.mock("@/utils/content", () => ({
+  extractYouTubeId: () => null,
+  youtubeThumbnail: (id: string) => `https://img.youtube.com/vi/${id}/maxresdefault.jpg`,
   getBlogPosts: () => [
     {
       title: "Blog Post One",

--- a/frontend/src/pages/BlogPostPage.test.tsx
+++ b/frontend/src/pages/BlogPostPage.test.tsx
@@ -5,6 +5,8 @@ import { MemoryRouter, Routes, Route } from "react-router";
 import { BlogPostPage } from "./BlogPostPage";
 
 vi.mock("@/utils/content", () => ({
+  extractYouTubeId: () => null,
+  youtubeThumbnail: (id: string) => `https://img.youtube.com/vi/${id}/maxresdefault.jpg`,
   getBlogPost: (slug: string) => {
     if (slug === "test-post") {
       return {

--- a/frontend/src/pages/ContactPage.test.tsx
+++ b/frontend/src/pages/ContactPage.test.tsx
@@ -4,6 +4,8 @@ import { render, screen, cleanup, act, fireEvent } from "@testing-library/react"
 import { ContactPage } from "./ContactPage";
 
 vi.mock("@/utils/content", () => ({
+  extractYouTubeId: () => null,
+  youtubeThumbnail: (id: string) => `https://img.youtube.com/vi/${id}/maxresdefault.jpg`,
   getHomeData: () => ({
     hero: {
       email: "sean@example.com",

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -13,6 +13,8 @@ vi.mock("framer-motion", async (importOriginal) => {
 });
 
 vi.mock("@/utils/content", () => ({
+  extractYouTubeId: () => null,
+  youtubeThumbnail: (id: string) => `https://img.youtube.com/vi/${id}/maxresdefault.jpg`,
   getHomeData: () => ({
     hero: {
       name: "Sean Bearden",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,7 +3,15 @@ import { ArrowRight, Mail, MessageSquare } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { getHomeData, getProjects, getBlogPosts, assetUrl, pdfUrl } from "@/utils/content";
+import {
+  getHomeData,
+  getProjects,
+  getBlogPosts,
+  assetUrl,
+  pdfUrl,
+  extractYouTubeId,
+  youtubeThumbnail,
+} from "@/utils/content";
 import { cn } from "@/lib/utils";
 import { motion, useReducedMotion } from "framer-motion";
 
@@ -129,10 +137,14 @@ export function HomePage() {
                 transition={{ duration: 0.5, delay: shouldReduce ? 0 : i * 0.1 }}
                 whileHover={shouldReduce ? undefined : { y: -5, boxShadow: "0 10px 30px -10px rgba(0,0,0,0.5)" }}
               >
-                {project.image && (
+                {(project.image || extractYouTubeId(project.link)) && (
                   <div className="aspect-video bg-muted shrink-0 overflow-hidden">
                     <motion.img
-                      src={assetUrl(project.image)}
+                      src={
+                        project.image
+                          ? assetUrl(project.image)
+                          : youtubeThumbnail(extractYouTubeId(project.link)!)
+                      }
                       alt={project.title}
                       className="h-full w-full object-cover"
                       loading="lazy"

--- a/frontend/src/pages/PortfolioPage.test.tsx
+++ b/frontend/src/pages/PortfolioPage.test.tsx
@@ -5,6 +5,8 @@ import { PortfolioPage } from "./PortfolioPage";
 import * as FramerMotion from "framer-motion";
 
 vi.mock("@/utils/content", () => ({
+  extractYouTubeId: () => null,
+  youtubeThumbnail: (id: string) => `https://img.youtube.com/vi/${id}/maxresdefault.jpg`,
   getProjects: () => [
     {
       title: "Portfolio Project 1",

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -1,6 +1,11 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { getProjects, assetUrl } from "@/utils/content";
+import {
+  getProjects,
+  assetUrl,
+  extractYouTubeId,
+  youtubeThumbnail,
+} from "@/utils/content";
 import { ExternalLink } from "lucide-react";
 import { motion, useReducedMotion } from "framer-motion";
 
@@ -39,10 +44,14 @@ export function PortfolioPage() {
             transition={{ duration: 0.5, delay: shouldReduce ? 0 : i * 0.1 }}
             whileHover={shouldReduce ? undefined : { y: -5, boxShadow: "0 10px 30px -10px rgba(0,0,0,0.5)" }}
           >
-            {project.image && (
+            {(project.image || extractYouTubeId(project.link)) && (
               <div className="aspect-video bg-muted overflow-hidden shrink-0">
                 <motion.img
-                  src={assetUrl(project.image)}
+                  src={
+                    project.image
+                      ? assetUrl(project.image)
+                      : youtubeThumbnail(extractYouTubeId(project.link)!)
+                  }
                   alt={project.title}
                   className="h-full w-full object-cover"
                   loading="lazy"

--- a/frontend/src/pages/PublicationsPage.test.tsx
+++ b/frontend/src/pages/PublicationsPage.test.tsx
@@ -4,6 +4,8 @@ import { render, screen } from "@testing-library/react";
 import { PublicationsPage } from "./PublicationsPage";
 
 vi.mock("@/utils/content", () => ({
+  extractYouTubeId: () => null,
+  youtubeThumbnail: (id: string) => `https://img.youtube.com/vi/${id}/maxresdefault.jpg`,
   getPublications: () => [
     {
       title: "Test Publication",

--- a/frontend/src/utils/content.test.ts
+++ b/frontend/src/utils/content.test.ts
@@ -6,7 +6,8 @@ import {
   parseAndSortProjects,
   getProjects,
   getPublications,
-  getHomeData
+  getHomeData,
+  extractYouTubeId,
 } from './content.ts';
 
 vi.mock("../../../content/publications.json", () => ({
@@ -142,5 +143,31 @@ describe('getHomeData', () => {
   it('should return the home data JSON', () => {
     const homeData = getHomeData();
     expect(homeData.hero.name).toBe('Test');
+  });
+});
+
+describe('extractYouTubeId', () => {
+  it('should extract ID from youtu.be links', () => {
+    expect(extractYouTubeId('https://youtu.be/wvPlTin-Nto')).toBe('wvPlTin-Nto');
+  });
+
+  it('should extract ID from youtube.com/watch links', () => {
+    expect(extractYouTubeId('https://www.youtube.com/watch?v=wvPlTin-Nto')).toBe('wvPlTin-Nto');
+  });
+
+  it('should extract ID from youtube.com/embed links', () => {
+    expect(extractYouTubeId('https://www.youtube.com/embed/wvPlTin-Nto')).toBe('wvPlTin-Nto');
+  });
+
+  it('should return null for non-YouTube links', () => {
+    expect(extractYouTubeId('https://example.com')).toBeNull();
+  });
+
+  it('should return null for undefined input', () => {
+    expect(extractYouTubeId(undefined)).toBeNull();
+  });
+
+  it('should extract ID with underscores and hyphens', () => {
+    expect(extractYouTubeId('https://youtu.be/abc_123-xyz')).toBe('abc_123-xyz');
   });
 });

--- a/frontend/src/utils/content.ts
+++ b/frontend/src/utils/content.ts
@@ -29,6 +29,25 @@ export function pdfUrl(filename: string): string {
   return `${ASSETS_BASE}/pdfs/${filename}`;
 }
 
+const YT_PATTERNS = [
+  /youtu\.be\/([\w-]{11})/, // https://youtu.be/wvPlTin-Nto
+  /youtube\.com\/watch\?v=([\w-]{11})/, // https://www.youtube.com/watch?v=wvPlTin-Nto
+  /youtube\.com\/embed\/([\w-]{11})/, // https://www.youtube.com/embed/wvPlTin-Nto
+];
+
+export function extractYouTubeId(url: string | undefined): string | null {
+  if (!url) return null;
+  for (const re of YT_PATTERNS) {
+    const m = url.match(re);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+export function youtubeThumbnail(videoId: string): string {
+  return `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
+}
+
 // --- Blog posts ---
 
 const blogModules = import.meta.glob<string>("../../../content/blog/*.md", {


### PR DESCRIPTION
This PR addresses the issue of missing thumbnails for portfolio projects that link to YouTube videos but do not have an explicit `image` field in their frontmatter.

Key changes:
- **New Utilities**: `extractYouTubeId` (supporting multiple YouTube URL formats) and `youtubeThumbnail` (returning the `maxresdefault.jpg` URL).
- **UI Enhancements**: Both `HomePage` and `PortfolioPage` now fall back to the YouTube thumbnail if the project image is not defined.
- **Security**: The Nginx CSP has been updated to permit image loading from `https://img.youtube.com`.
- **Test Stability**: Mock definitions in several test files were updated to include the new exports from `@/utils/content`, ensuring existing tests continue to pass.
- **New Tests**: Unit tests for the YouTube ID extraction logic have been added to `content.test.ts`.

Verification:
- All frontend tests passed.
- Visual verification via Playwright confirmed that YouTube thumbnails are correctly rendered for affected cards (e.g., King Turing).

Fixes #136

---
*PR created automatically by Jules for task [4640018956405319172](https://jules.google.com/task/4640018956405319172) started by @seanbearden*