### PR TITLE
fix(contact): make email click do something visible without a mail client

### DIFF
--- a/.changeset/fix-contact-email-click.md
+++ b/.changeset/fix-contact-email-click.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Fix Contact page email link silently failing for users without a default mail client. Clicking the email now copies it to the clipboard with visible feedback while still attempting to open the user's mail app. Also redirects the Footer "Contact" link to the /contact page instead of mailto:.

--- a/frontend/src/components/layout/Footer.test.tsx
+++ b/frontend/src/components/layout/Footer.test.tsx
@@ -44,10 +44,13 @@ describe("Footer", () => {
     expect(resumeLink.getAttribute("href")).toContain("Bearden_Resume_Online.pdf");
   });
 
-  it("renders Contact link", () => {
+  it("renders Contact link to /contact (not mailto:, which silently fails without a mail client)", () => {
     renderFooter();
     const contactLink = screen.getByRole("link", { name: /contact/i });
     expect(contactLink).toBeInTheDocument();
-    expect(contactLink.getAttribute("href")).toBe("mailto:test@example.com");
+    expect(contactLink.getAttribute("href")).toBe("/contact");
+    // Regression guard: do NOT regress to mailto: — that silently fails for
+    // users whose browser/OS has no default mail client configured.
+    expect(contactLink.getAttribute("href")).not.toMatch(/^mailto:/);
   });
 });

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,9 +1,10 @@
-import { getHomeData, pdfUrl } from "@/utils/content";
+import { Link } from "react-router";
+import { pdfUrl } from "@/utils/content";
 import { motion } from "framer-motion";
 
-export function Footer() {
-  const home = getHomeData();
+const MotionLink = motion.create(Link);
 
+export function Footer() {
   return (
     <footer className="border-t border-border/50 py-8 mt-auto bg-card/30 backdrop-blur-sm">
       <div className="mx-auto max-w-5xl px-4 flex flex-col items-center gap-6 sm:flex-row sm:justify-between">
@@ -26,14 +27,14 @@ export function Footer() {
             Resume
             <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-primary transition-all group-hover:w-full" />
           </motion.a>
-          <motion.a
-            href={`mailto:${home.hero.email}`}
+          <MotionLink
+            to="/contact"
             className="text-sm font-medium text-muted-foreground hover:text-primary transition-colors relative group"
             whileHover={{ y: -1 }}
           >
             Contact
             <span className="absolute -bottom-1 left-0 w-0 h-0.5 bg-primary transition-all group-hover:w-full" />
-          </motion.a>
+          </MotionLink>
         </div>
       </div>
     </footer>

--- a/frontend/src/pages/ContactPage.test.tsx
+++ b/frontend/src/pages/ContactPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, act, fireEvent } from "@testing-library/react";
 import { ContactPage } from "./ContactPage";
 
 vi.mock("@/utils/content", () => ({
@@ -22,6 +22,11 @@ vi.mock("@/components/common/SocialIcons", () => ({
 }));
 
 describe("ContactPage", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
   it("renders contact info and supported social links", () => {
     render(<ContactPage />);
 
@@ -33,9 +38,88 @@ describe("ContactPage", () => {
     const emailLink = screen.getByRole("link", { name: /sean@example.com/i });
     expect(emailLink).toHaveAttribute("href", "mailto:sean@example.com");
   });
+
+  it("copies email to clipboard on click and shows feedback (regression guard for silently-failing mailto:)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<ContactPage />);
+
+    const emailLink = screen.getByRole("link", { name: /Email sean@example.com/i });
+
+    // Prevent jsdom from attempting actual mailto: navigation
+    emailLink.addEventListener("click", (e) => e.preventDefault(), { once: true });
+    fireEvent.click(emailLink);
+
+    expect(writeText).toHaveBeenCalledWith("sean@example.com");
+    expect(screen.getByText("Copied!")).toBeInTheDocument();
+    expect(screen.getByText("Email copied to clipboard.")).toBeInTheDocument();
+
+    // Feedback clears after 2s
+    act(() => vi.advanceTimersByTime(2000));
+    expect(screen.queryByText("Copied!")).not.toBeInTheDocument();
+    expect(screen.getByText("sean@example.com")).toBeInTheDocument();
+  });
+
+  it("does not preventDefault on click — preserves mailto: navigation for users with a mail client", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+
+    render(<ContactPage />);
+    const emailLink = screen.getByRole("link", { name: /Email sean@example.com/i });
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    emailLink.dispatchEvent(event);
+
+    // If the handler called preventDefault, mailto: would be suppressed for
+    // users who DO have a mail client. Make sure it doesn't.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("survives clipboard.writeText rejection (e.g. permission denied) without throwing", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("permission denied"));
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<ContactPage />);
+    const emailLink = screen.getByRole("link", { name: /Email sean@example.com/i });
+    emailLink.addEventListener("click", (e) => e.preventDefault(), { once: true });
+
+    // Should not throw even though writeText rejects
+    fireEvent.click(emailLink);
+
+    // UI feedback still fires regardless of clipboard outcome
+    expect(screen.getByText("Copied!")).toBeInTheDocument();
+  });
 });
 
 describe("ContactPage with reduced motion", () => {
+  beforeEach(() => {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query.includes("prefers-reduced-motion: reduce"),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    cleanup();
+  });
+
   it("renders correctly when prefers-reduced-motion is set", () => {
     render(<ContactPage />);
     expect(screen.getByText("Get in Touch")).toBeInTheDocument();

--- a/frontend/src/pages/ContactPage.tsx
+++ b/frontend/src/pages/ContactPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { getHomeData } from "@/utils/content";
 import { buttonVariants } from "@/components/ui/button";
 import { Mail } from "lucide-react";
@@ -6,6 +7,20 @@ import { cn } from "@/lib/utils";
 
 export function ContactPage() {
   const home = getHomeData();
+  const [copied, setCopied] = useState(false);
+
+  // mailto: links silently fail for users whose browser/OS has no default
+  // mail client configured. Copy the address to the clipboard on every click
+  // so SOMETHING visible happens, even if mailto: doesn't open a mail app.
+  // We don't preventDefault — the browser still attempts mailto: navigation
+  // for users who DO have a mail client.
+  const handleEmailClick = () => {
+    navigator.clipboard?.writeText(home.hero.email).catch(() => {
+      /* clipboard may be unavailable in insecure contexts; ignore */
+    });
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
 
   return (
     <div className="mx-auto max-w-xl px-4 py-12 text-center">
@@ -16,10 +31,16 @@ export function ContactPage() {
 
       <a
         href={`mailto:${home.hero.email}`}
+        onClick={handleEmailClick}
+        aria-label={`Email ${home.hero.email}`}
         className={cn(buttonVariants({ size: "lg" }), "mt-8")}
       >
-        <Mail className="mr-2 h-5 w-5" /> {home.hero.email}
+        <Mail className="mr-2 h-5 w-5" />
+        {copied ? "Copied!" : home.hero.email}
       </a>
+      <p className="mt-2 text-xs text-muted-foreground" aria-live="polite">
+        {copied ? "Email copied to clipboard." : "Click the address to copy or open your mail app."}
+      </p>
 
       <div className="mt-10 flex justify-center gap-4">
         {Object.entries(home.social).map(([platform, url]) => {


### PR DESCRIPTION
## Summary

User reported clicking the email on https://seanbearden.com/contact did nothing. Root cause: `mailto:` links silently fail when the browser/OS has no default mail client configured (common on macOS without Mail.app set up, or browsers without a default web-mail handler).

## Fix

### ContactPage
- Keep the `mailto:` href so users with mail clients still get their app to open
- Add `onClick` that copies the address to the clipboard and shows \"Copied!\" feedback for 2s, plus a small status line below the button
- Don't `preventDefault` — mailto: navigation still attempts for those who can use it
- `aria-label` and `aria-live=\"polite\"` for accessibility

### Footer
- Change the \"Contact\" link from `mailto:` → React Router `<Link>` to `/contact`. A footer \"Contact\" link should land on the contact page (which now has the working click-to-copy), not silently fail.

## Regression tests

`frontend/src/pages/ContactPage.test.tsx` adds 3 new tests:

1. **Clipboard write + feedback**: clicking the email calls `navigator.clipboard.writeText(\"sean@example.com\")`, shows \"Copied!\" feedback, then clears after 2s
2. **Doesn't preventDefault**: the click handler must NOT cancel the event, otherwise mailto: navigation is suppressed for users who do have a mail client
3. **Survives clipboard rejection**: if `clipboard.writeText` rejects (permission denied, insecure context), the UI feedback still fires and nothing throws

`frontend/src/components/layout/Footer.test.tsx` asserts:
- Contact link href is `/contact`
- Explicit regression guard: href is **not** mailto:

## Test plan

- [x] `npx vitest run` — all 85 tests pass (3 new ContactPage tests, 1 updated Footer test)
- [x] `npm run build` — clean
- [ ] After merge: visit https://seanbearden.com/contact, click the email, see \"Copied!\" feedback, paste somewhere to verify the address copied
- [ ] Visit https://seanbearden.com from any page, click \"Contact\" in the footer — lands on `/contact`

## Changeset

Included: `.changeset/fix-contact-email-click.md` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes the email-click bug.