### PR TITLE
fix(content): broken press URLs (UB Goldwater 404, Ohio Today domain reorg)

### DIFF
--- a/.changeset/fix-ub-goldwater-press-url.md
+++ b/.changeset/fix-ub-goldwater-press-url.md
@@ -1,0 +1,5 @@
+---
+"portfolio": patch
+---
+
+Fix broken UB Goldwater Scholars press link on home page (UB reorganized the news URL path; new URL points to the same article with its actual title).

--- a/content/home.json
+++ b/content/home.json
@@ -131,8 +131,8 @@
     {
       "title": "Leading through education",
       "source": "Ohio Today",
-      "date": "2016",
-      "url": "https://ohiotoday.org/spring-2016/leading-through-education/"
+      "date": "2016-03",
+      "url": "https://www.ohio.edu/news/2016/03/leading-through-education"
     },
     {
       "title": "Sean Bearden's redemption road",

--- a/content/home.json
+++ b/content/home.json
@@ -153,10 +153,10 @@
       "url": "https://www.ubspectrum.com/article/2015/05/ubs-outstanding-seniors-receive-awards-from-the-college-of-arts-and-sciences"
     },
     {
-      "title": "UB students named Goldwater Scholars",
+      "title": "Two UB students win highly competitive Goldwater Scholarships",
       "source": "UB News",
       "date": "2014-03",
-      "url": "https://www.buffalo.edu/fellowships/start/scholars.host.html/content/shared/university/news/news-center-releases/2014/03/048.detail.html"
+      "url": "https://www.buffalo.edu/news/releases/2014/03/048.html"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two broken press links on the home page from upstream domain reorgs:

| Source | Old URL | Status | New URL |
|---|---|---|---|
| **UB News** (Goldwater) | `buffalo.edu/fellowships/start/scholars.host.html/.../2014/03/048.detail.html` | 404 | [`buffalo.edu/news/releases/2014/03/048.html`](https://www.buffalo.edu/news/releases/2014/03/048.html) |
| **Ohio Today** | `ohiotoday.org/spring-2016/leading-through-education/` | 301 to magazine landing page | [`ohio.edu/news/2016/03/leading-through-education`](https://www.ohio.edu/news/2016/03/leading-through-education) |

Both new URLs verified 200 + content matches (Bearden + article keywords).

## Why each broke

**UB Goldwater**: Buffalo reorganized their news URL paths. Path `/fellowships/start/scholars.host.html/...` no longer routes; canonical news releases now live at `/news/releases/YYYY/MM/NNN.html`. Title also corrected from \"UB students named Goldwater Scholars\" (paraphrase) to the article's actual title \"Two UB students win highly competitive Goldwater Scholarships.\"

**Ohio Today**: Ohio University retired the standalone `ohiotoday.org` domain and folded the magazine into `www.ohio.edu/news/magazine`. Critically, they **don't redirect old article URLs to their new equivalents** — every `ohiotoday.org/...` path 301s to the same magazine landing page, which is useless. Found the actual article via search. Also tightened the date field from \"2016\" to \"2016-03\" to match the publish month on the new page.

## Audit of related URLs

I checked all 7 press URLs in `home.json`:

| URL | Status |
|---|---|
| `physicstoday.scitation.org/.../PT.6.4.20200501a/...` (Physics Today Q&A) | 200 |
| `storycollider.org/.../a-whole-new-world-...` (Story Collider) | 200 |
| `ohio.edu/news/2016/03/leading-through-education` (this fix) | 200 |
| `buffalo.edu/fellowships/start/our-scholars.host.html/.../bearden_nsf_grad_fellowship.detail.html` (UB Reporter NSF) | 200 |
| `buffalonews.com/2015/06/21/prison-adds-up-...` (Buffalo News) | 200 |
| `ubspectrum.com/article/2015/05/ubs-outstanding-seniors-...` (Spectrum) | 200 |
| `buffalo.edu/news/releases/2014/03/048.html` (this fix) | 200 |

All 7 alive after these two fixes.

## Test plan

- [x] Both replacement URLs `curl` to 200
- [x] Content verified to be the right articles (`grep` for Bearden + topic keywords)
- [ ] After merge: visit https://seanbearden.com — Press section, click both fixed links → real articles load

## Changeset

Included: `.changeset/fix-ub-goldwater-press-url.md` (patch). The single changeset covers both fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)