### PR TITLE
Add TruffleHog secret scanning to CI

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,39 @@
+name: TruffleHog Secret Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "0 8 * * 1"  # Mondays 08:00 UTC, after ZAP
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for full-scan modes
+
+      - name: TruffleHog OSS (Scan Diff)
+        if: github.event_name != 'schedule'
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26  # v3.95.2
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --only-verified
+
+      - name: TruffleHog OSS (Full History)
+        if: github.event_name == 'schedule'
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26  # v3.95.2
+        with:
+          path: ./
+          extra_args: --only-verified

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -18,22 +18,34 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0  # full history for full-scan modes
+          # Full history is needed for the weekly scheduled scan (which scans
+          # all commits, not just the diff). For PR/push events the action
+          # only needs the diff and ignores the rest.
+          fetch-depth: 0
 
-      - name: TruffleHog OSS (Scan Diff)
+      # PR + push events: scan only the diff. Don't pass base/head explicitly —
+      # the action auto-derives them from the GitHub event payload using SHAs
+      # (which always resolve), avoiding the "unable to resolve ref" error
+      # that came from passing the bare branch name "main" as base.
+      # See https://github.com/trufflesecurity/trufflehog#github-action.
+      - name: TruffleHog (diff scan on PR/push)
         if: github.event_name != 'schedule'
         uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26  # v3.95.2
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
           extra_args: --only-verified
 
-      - name: TruffleHog OSS (Full History)
+      # Weekly cron: scan full git history. Setting base= empty + head=HEAD
+      # tells TruffleHog to scan every commit in the repo. fetch-depth: 0
+      # above is what makes this useful — without it, the action would only
+      # see the latest commit on a shallow clone.
+      - name: TruffleHog (full history weekly)
         if: github.event_name == 'schedule'
         uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26  # v3.95.2
         with:
           path: ./
+          base: ""
+          head: HEAD
           extra_args: --only-verified


### PR DESCRIPTION
This PR adds TruffleHog to the CI pipeline to proactively detect and prevent credential leakage. 

Key features:
- **Scan Modes**: 
  - PR/Push: Scans only the diff for fast feedback.
  - Weekly Schedule (Mondays 08:00 UTC): Performs a full-history scan to catch any latent secrets.
- **Verification**: Uses the `--only-verified` flag to ensure that only actionable findings (active credentials) are reported.
- **Security**: The GitHub Action is pinned to a specific commit SHA (`17456f8c7d042d8c82c9a8ca9e937231f9f42e26`) as per repository policy.
- **Onboarding**: A manual full-history scan was performed locally, and no pre-existing verified secrets were found.

Scan output from local verification:
```
{"level":"info-0","ts":"...","logger":"trufflehog","msg":"finished scanning","chunks":4640,"bytes":18290164,"verified_secrets":0,"unverified_secrets":0,"scan_duration":"10.583423869s","trufflehog_version":"3.95.2",...}
```

No changesets are included as this change only affects CI workflows.

Fixes #142

---
*PR created automatically by Jules for task [14551327388071435105](https://jules.google.com/task/14551327388071435105) started by @seanbearden*