### PR TITLE
ci(security): inline ZAP baseline scan into deploy.yml after deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,3 +72,33 @@ jobs:
           echo "## Deployment Complete" >> "$GITHUB_STEP_SUMMARY"
           echo "- **URL**: ${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Version**: \`${{ steps.version.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  # Run ZAP baseline against the just-deployed production URL. Inlined here
+  # rather than as a separate workflow with `workflow_run: ["Deploy"]` because
+  # GitHub blocks workflow_run listeners from firing when the upstream
+  # workflow was triggered by GITHUB_TOKEN (anti-recursion guard). When
+  # release.yml dispatches Deploy via `gh workflow run` using GITHUB_TOKEN
+  # (per PR #101), the listener never fires. Inlining sidesteps that.
+  # The standalone .github/workflows/zap-baseline.yml still handles the
+  # weekly cron and ad-hoc workflow_dispatch.
+  zap-scan:
+    name: ZAP baseline scan (post-deploy)
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run ZAP baseline scan
+        uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
+        with:
+          target: "https://seanbearden.com"
+          docker_name: "ghcr.io/zaproxy/zaproxy:stable"
+          rules_file_name: ".zap/rules.tsv"
+          cmd_options: "-a"
+          fail_action: false
+          allow_issue_writing: true
+          artifact_name: "zap-baseline-report-${{ github.run_id }}"

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -1,11 +1,12 @@
 name: ZAP Baseline
 
 on:
+  # Weekly cadence catches drift (new ZAP rules, upstream changes) even when
+  # we haven't deployed. Post-deploy scans happen inline in deploy.yml itself
+  # (workflow_run listeners are blocked when Deploy is triggered by
+  # GITHUB_TOKEN — see deploy.yml's zap-scan job for context).
   schedule:
     - cron: "0 6 * * 1"  # Mondays 06:00 UTC
-  workflow_run:
-    workflows: ["Deploy"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       target:
@@ -20,7 +21,6 @@ permissions:
 jobs:
   baseline:
     name: ZAP baseline scan
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

Post-deploy ZAP baseline scans have been silently skipped on every release. Found this while investigating why the latest deploy (v0.3.2 today) didn't trigger a scan.

## Root cause

GitHub's anti-recursion guard blocks `workflow_run` listeners from firing when the upstream workflow was triggered by \`GITHUB_TOKEN\`. After PR #101, \`release.yml\` dispatches \`deploy.yml\` via \`gh workflow run --ref TAG\` using \`GITHUB_TOKEN\`. So every release-triggered deploy runs as:

- \`event: workflow_dispatch\`
- \`actor: github-actions[bot]\`
- \`triggering_actor: github-actions[bot]\`

…and \`zap-baseline.yml\`'s \`workflow_run: workflows: [\"Deploy\"]\` listener never sees it.

Verified on deploy run \`25289321930\` (v0.3.2): succeeded at 19:59 UTC today, zero ZAP baseline runs from \`workflow_run\` afterward.

## Fix

Move the post-deploy ZAP scan into \`deploy.yml\` itself as a \`zap-scan\` job with \`needs: deploy\`. Same workflow run, same trigger context — the anti-recursion guard doesn't apply **within** a single workflow's job graph.

Standalone \`zap-baseline.yml\` still handles:
- Weekly cron (Mondays 06:00 UTC) — catches drift from new ZAP rules / upstream changes
- \`workflow_dispatch\` — ad-hoc scans with optional custom target URL

The dead \`workflow_run\` trigger and its \`if:\` guard are removed from \`zap-baseline.yml\` since the inline scan supersedes it. Cross-references between the two files explain the split for future maintainers.

## Test plan

- [x] Diff is workflow-only, ~30 lines added to deploy.yml + 6 line cleanup in zap-baseline.yml
- [ ] After merge: next release (any new PR merged → release version PR merged → deploy fires) should produce a Deploy workflow run with two completed jobs (\`deploy\` then \`zap-scan\`)
- [ ] ZAP report artifact appears in the run's summary
- [ ] If new findings: a ZAP-authored issue gets auto-labeled \`jules\` + \`security\` per the existing \`auto-label-zap-issues.yml\` workflow

## Why no changeset

\`.github/workflows/**\` is on the AGENTS.md skip list (CI doesn't ship in the runtime bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)