### PR TITLE
docs(readme): add CI + security workflow badges + Mozilla Observatory grade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Sean Bearden — Portfolio Website
 
+[![CI](https://github.com/seanbearden/portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/seanbearden/portfolio/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/seanbearden/portfolio/actions/workflows/codeql.yml/badge.svg)](https://github.com/seanbearden/portfolio/actions/workflows/codeql.yml)
+[![TruffleHog](https://github.com/seanbearden/portfolio/actions/workflows/trufflehog.yml/badge.svg)](https://github.com/seanbearden/portfolio/actions/workflows/trufflehog.yml)
+[![ZAP Baseline](https://github.com/seanbearden/portfolio/actions/workflows/zap-baseline.yml/badge.svg)](https://github.com/seanbearden/portfolio/actions/workflows/zap-baseline.yml)
+[![Mozilla Observatory](https://img.shields.io/mozilla-observatory/grade/seanbearden.com?publish&label=observatory)](https://observatory.mozilla.org/analyze/seanbearden.com)
 [![codecov](https://codecov.io/gh/seanbearden/portfolio/graph/badge.svg?token=JgoqNrfl9G)](https://codecov.io/gh/seanbearden/portfolio)
 
 Live at **[seanbearden.com](https://seanbearden.com)** — also serving on `www.seanbearden.com`.


### PR DESCRIPTION
## Summary

Adds five badges to the README header next to the existing Codecov badge.

| Badge | Source | What it shows |
|---|---|---|
| **CI** | `actions/workflows/ci.yml/badge.svg` | Overall test + build status on main |
| **CodeQL** | `actions/workflows/codeql.yml/badge.svg` | Latest SAST scan status |
| **TruffleHog** | `actions/workflows/trufflehog.yml/badge.svg` | Latest secret-scan status |
| **ZAP Baseline** | `actions/workflows/zap-baseline.yml/badge.svg` | Latest DAST scan status |
| **Mozilla Observatory** | `img.shields.io/mozilla-observatory/grade/seanbearden.com` | **Live** grade of the running site (not CI-derived) |

The first four are GitHub's generic Actions workflow badge format — auto-updates as runs complete. The Observatory badge is shields.io-sourced and reflects whatever grade observatory.mozilla.org currently has cached for the domain (refreshed weekly by our `security-headers.yml` workflow).

## Why these five

- **CI**: at-a-glance "tests pass" — most useful info for any visitor
- **CodeQL + TruffleHog + ZAP**: visible proof of automated security posture (SAST + secret scanning + DAST)
- **Observatory**: the only badge that reflects the **actual deployed site**, not just CI status

## Skipped

- Deploy status — runs only on tagged releases, often shows "no recent run" (looks worse than informative)
- LICENSE / activity / stack-vanity badges — low signal

## Test plan

- [x] All five URLs return valid SVG when fetched directly (verified manually)
- [ ] After merge: visit github.com/seanbearden/portfolio and confirm all 6 badges render and link to the right destinations
- [ ] Observatory badge shows a real grade (or "N/A" if the host hasn't been scanned in their cache window — should populate within ~1 week of the next `security-headers.yml` run)

## Why no changeset

`*.md documentation` is on the AGENTS.md changeset skip list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)