### PR TITLE
Triage ZAP baseline scan alerts

### DIFF
--- a/.changeset/zap-scan-triage.md
+++ b/.changeset/zap-scan-triage.md
@@ -1,0 +1,8 @@
+---
+"portfolio": patch
+---
+
+Triage ZAP baseline scan alerts:
+- Resolved Information Disclosure (Rule 10027) by removing a deployment-related comment from `sitemap.xml`.
+- Documented accepted trade-offs for caching policies (Rules 10049, 10015) in `nginx.conf.template`, favoring freshness for HTML and performance for static assets.
+- Re-confirmed that existing justifications for CSP `style-src 'unsafe-inline'` (Rule 10055) and COEP `unsafe-none` (Rule 90004) in `nginx.conf.template` remain necessary for compatibility with framer-motion and GCS assets, respectively.

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -39,6 +39,15 @@ server {
     add_header Cross-Origin-Embedder-Policy "unsafe-none" always;
     add_header Cross-Origin-Resource-Policy "same-origin" always;
 
+    # Caching strategy:
+    # ZAP rule 10049 (Non-Storable Content) reports 'no-store' or 'no-cache'
+    # on HTML responses. We intentionally use these for index.html and SPA
+    # routes to ensure users immediately receive the new version after a
+    # deployment. ZAP rules 10049 (Storable Content) and 10015 (Cache-Control)
+    # also report on 'public' caching of assets. We use long-term caching
+    # for hashed assets and short-term for others to balance performance
+    # and freshness. All are accepted as audit trails — do NOT silence.
+
     # Phase 2: uncomment to proxy chatbot API
     # location /api/ {
     #     proxy_pass ${CHATBOT_API_URL}/api/;

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -39,14 +39,15 @@ server {
     add_header Cross-Origin-Embedder-Policy "unsafe-none" always;
     add_header Cross-Origin-Resource-Policy "same-origin" always;
 
-    # Caching strategy:
-    # ZAP rule 10049 (Non-Storable Content) reports 'no-store' or 'no-cache'
-    # on HTML responses. We intentionally use these for index.html and SPA
-    # routes to ensure users immediately receive the new version after a
-    # deployment. ZAP rules 10049 (Storable Content) and 10015 (Cache-Control)
-    # also report on 'public' caching of assets. We use long-term caching
-    # for hashed assets and short-term for others to balance performance
-    # and freshness. All are accepted as audit trails — do NOT silence.
+    # Caching strategy — accepted ZAP alerts:
+    # Two rules fire on our deliberate caching choices:
+    # - 10049 covers both sub-alerts: "Non-Storable Content" (for HTML with
+    #   no-store/no-cache, intentional so deploys are picked up immediately)
+    #   and "Storable and Cacheable Content" (for `public` caching on hashed
+    #   assets, intentional so they're long-term immutable).
+    # - 10015 ("Re-examine Cache-control Directives") is the generic
+    #   meta-alert that fires alongside 10049 on the same responses.
+    # Both are accepted as audit trails — do NOT silence.
 
     # Phase 2: uncomment to proxy chatbot API
     # location /api/ {

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Note: Hostname is set to seanbearden.com, but the DNS cutover from Squarespace
-  to this Cloud Run service hasn't occurred yet.
--->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://seanbearden.com/</loc>


### PR DESCRIPTION
This PR triages the latest ZAP baseline scan alerts for seanbearden.com.

Key changes:
- **Rule 10027 (Suspicious Comments):** Removed a deployment-related "Note" comment from `frontend/public/sitemap.xml` that was flagging as suspicious.
- **Rules 10049 & 10015 (Caching):** Added explicit documentation in `frontend/nginx.conf.template` explaining the tiered caching strategy (no-cache for HTML to ensure freshness vs. public caching for assets for performance). These are accepted trade-offs.
- **Triage Documentation:** The changeset explicitly lists the triage rationale for all significant findings (CSP, COEP, Caching, Comments) to satisfy security audit requirements and provide a clear history of decision-making.

All frontend tests passed.

Fixes #150

---
*PR created automatically by Jules for task [10231443620776042994](https://jules.google.com/task/10231443620776042994) started by @seanbearden*