### PR TITLE
Add decorative SVG section dividers

### DIFF
--- a/.changeset/add-section-dividers.md
+++ b/.changeset/add-section-dividers.md
@@ -1,0 +1,5 @@
+---
+"portfolio": minor
+---
+
+Add decorative SVG section dividers for improved visual rhythm across Home, About, and Blog pages.

--- a/frontend/src/components/ui/section-divider.tsx
+++ b/frontend/src/components/ui/section-divider.tsx
@@ -7,7 +7,7 @@ interface SectionDividerProps {
 
 export function SectionDivider({ variant = "lines", className }: SectionDividerProps) {
   return (
-    <div className={cn("w-full py-12 flex justify-center overflow-hidden", className)} aria-hidden="true">
+    <div className={cn("w-full py-8 flex justify-center overflow-hidden", className)} aria-hidden="true">
       {variant === "waves" && (
         <svg
           width="100%"
@@ -43,15 +43,12 @@ export function SectionDivider({ variant = "lines", className }: SectionDividerP
           xmlns="http://www.w3.org/2000/svg"
           className="text-primary/40"
         >
-          <circle cx="20" cy="6" r="2.5" fill="currentColor" />
-          <circle cx="50" cy="6" r="2.5" fill="currentColor" />
-          <circle cx="80" cy="6" r="2.5" fill="currentColor" />
-          <circle cx="110" cy="6" r="2.5" fill="currentColor" />
-          <circle cx="140" cy="6" r="2.5" fill="currentColor" />
-          <circle cx="35" cy="6" r="1.2" fill="currentColor" opacity="0.5" />
-          <circle cx="65" cy="6" r="1.2" fill="currentColor" opacity="0.5" />
-          <circle cx="95" cy="6" r="1.2" fill="currentColor" opacity="0.5" />
-          <circle cx="125" cy="6" r="1.2" fill="currentColor" opacity="0.5" />
+          {[20, 50, 80, 110, 140].map((cx) => (
+            <circle key={cx} cx={cx} cy="6" r="2.5" fill="currentColor" />
+          ))}
+          {[35, 65, 95, 125].map((cx) => (
+            <circle key={cx} cx={cx} cy="6" r="1.2" fill="currentColor" opacity="0.5" />
+          ))}
         </svg>
       )}
 

--- a/frontend/src/components/ui/section-divider.tsx
+++ b/frontend/src/components/ui/section-divider.tsx
@@ -1,0 +1,102 @@
+import { cn } from "@/lib/utils";
+
+interface SectionDividerProps {
+  variant?: "waves" | "lines" | "dots" | "network" | "particles";
+  className?: string;
+}
+
+export function SectionDivider({ variant = "lines", className }: SectionDividerProps) {
+  return (
+    <div className={cn("w-full py-12 flex justify-center overflow-hidden", className)} aria-hidden="true">
+      {variant === "waves" && (
+        <svg
+          width="100%"
+          height="24"
+          viewBox="0 0 1200 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="text-primary/20"
+        >
+          <path
+            d="M0 12C150 24 300 0 450 12C600 24 750 0 900 12C1050 24 1200 12 1200 12"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      )}
+
+      {variant === "lines" && (
+        <div className="flex flex-col items-center gap-2 w-full max-w-md">
+          <div className="h-px w-full bg-border/60 rounded-full" />
+          <div className="h-px w-2/3 bg-border/40 rounded-full" />
+          <div className="h-px w-1/3 bg-border/20 rounded-full" />
+        </div>
+      )}
+
+      {variant === "dots" && (
+        <svg
+          width="160"
+          height="12"
+          viewBox="0 0 160 12"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="text-primary/40"
+        >
+          <circle cx="20" cy="6" r="2.5" fill="currentColor" />
+          <circle cx="50" cy="6" r="2.5" fill="currentColor" />
+          <circle cx="80" cy="6" r="2.5" fill="currentColor" />
+          <circle cx="110" cy="6" r="2.5" fill="currentColor" />
+          <circle cx="140" cy="6" r="2.5" fill="currentColor" />
+          <circle cx="35" cy="6" r="1.2" fill="currentColor" opacity="0.5" />
+          <circle cx="65" cy="6" r="1.2" fill="currentColor" opacity="0.5" />
+          <circle cx="95" cy="6" r="1.2" fill="currentColor" opacity="0.5" />
+          <circle cx="125" cy="6" r="1.2" fill="currentColor" opacity="0.5" />
+        </svg>
+      )}
+
+      {variant === "network" && (
+        <svg
+          width="200"
+          height="40"
+          viewBox="0 0 200 40"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="text-primary/30"
+        >
+          <circle cx="30" cy="20" r="3.5" fill="currentColor" />
+          <circle cx="80" cy="10" r="2.5" fill="currentColor" />
+          <circle cx="130" cy="30" r="2.5" fill="currentColor" />
+          <circle cx="180" cy="20" r="3.5" fill="currentColor" />
+          <line x1="34" y1="20" x2="76" y2="11" stroke="currentColor" strokeWidth="1" strokeDasharray="3 3" />
+          <line x1="84" y1="11" x2="126" y2="29" stroke="currentColor" strokeWidth="1" strokeDasharray="3 3" />
+          <line x1="134" y1="29" x2="176" y2="21" stroke="currentColor" strokeWidth="1" strokeDasharray="3 3" />
+        </svg>
+      )}
+
+      {variant === "particles" && (
+        <svg
+          width="240"
+          height="48"
+          viewBox="0 0 240 48"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="text-primary/25"
+        >
+          <circle cx="30" cy="12" r="2" fill="currentColor" />
+          <circle cx="60" cy="36" r="1.5" fill="currentColor" />
+          <circle cx="90" cy="18" r="2.5" fill="currentColor" />
+          <circle cx="120" cy="30" r="1.5" fill="currentColor" />
+          <circle cx="150" cy="12" r="1.5" fill="currentColor" />
+          <circle cx="180" cy="42" r="2.5" fill="currentColor" />
+          <circle cx="210" cy="24" r="2" fill="currentColor" />
+          <circle cx="45" cy="30" r="0.8" fill="currentColor" opacity="0.5" />
+          <circle cx="105" cy="42" r="0.8" fill="currentColor" opacity="0.5" />
+          <circle cx="135" cy="6" r="0.8" fill="currentColor" opacity="0.5" />
+          <circle cx="165" cy="30" r="0.8" fill="currentColor" opacity="0.5" />
+          <circle cx="225" cy="6" r="0.8" fill="currentColor" opacity="0.5" />
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
+import { SectionDivider } from "@/components/ui/section-divider";
 import { buttonVariants } from "@/components/ui/button";
 import { getHomeData, pdfUrl } from "@/utils/content";
 import { Award, Briefcase, GraduationCap, Download, Heart, Newspaper, ExternalLink } from "lucide-react";
@@ -45,7 +45,7 @@ export function AboutPage() {
         </a>
       </div>
 
-      <Separator className="my-10" />
+      <SectionDivider variant="lines" className="my-4 opacity-50" />
 
       {/* Experience */}
       <section>
@@ -73,7 +73,7 @@ export function AboutPage() {
         </div>
       </section>
 
-      <Separator className="my-10" />
+      <SectionDivider variant="dots" className="my-4 opacity-50" />
 
       {/* Education */}
       <section>
@@ -93,7 +93,7 @@ export function AboutPage() {
         </div>
       </section>
 
-      <Separator className="my-10" />
+      <SectionDivider variant="network" className="my-4 opacity-50" />
 
       {/* Awards */}
       <section>
@@ -107,7 +107,7 @@ export function AboutPage() {
         </ul>
       </section>
 
-      <Separator className="my-10" />
+      <SectionDivider variant="waves" className="my-4 opacity-50" />
 
       {/* Press & Media */}
       <section>
@@ -136,7 +136,7 @@ export function AboutPage() {
         </ul>
       </section>
 
-      <Separator className="my-10" />
+      <SectionDivider variant="particles" className="my-4 opacity-50" />
 
       {/* Skills */}
       <section>
@@ -157,7 +157,7 @@ export function AboutPage() {
         </div>
       </section>
 
-      <Separator className="my-10" />
+      <SectionDivider variant="dots" className="my-4 opacity-50" />
 
       {/* Beyond Work */}
       <section>

--- a/frontend/src/pages/BlogPage.tsx
+++ b/frontend/src/pages/BlogPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 import { Badge } from "@/components/ui/badge";
 import { getBlogPosts, assetUrl } from "@/utils/content";
+import { SectionDivider } from "@/components/ui/section-divider";
 
 export function BlogPage() {
   const posts = getBlogPosts();
@@ -12,7 +13,9 @@ export function BlogPage() {
         Writing about data science, AI, cloud architecture, and the journey from physics to tech.
       </p>
 
-      <div className="mt-8 space-y-6">
+      <SectionDivider variant="lines" className="mt-4 opacity-50" />
+
+      <div className="mt-4 space-y-6">
         {posts.map((post) => (
           <Link
             key={post.slug}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/utils/content";
 import { cn } from "@/lib/utils";
 import { motion, useReducedMotion } from "framer-motion";
+import { SectionDivider } from "@/components/ui/section-divider";
 
 const MotionCard = motion.create(Card);
 
@@ -112,6 +113,8 @@ export function HomePage() {
         </motion.div>
       </section>
 
+      <SectionDivider variant="waves" className="opacity-50" />
+
       {/* Featured Projects */}
       <section className="py-12">
         <motion.div
@@ -186,6 +189,8 @@ export function HomePage() {
         </motion.div>
       </section>
 
+      <SectionDivider variant="network" className="opacity-50" />
+
       {/* Recent Posts */}
       <section className="py-12">
         <motion.div
@@ -234,6 +239,8 @@ export function HomePage() {
           </div>
         </motion.div>
       </section>
+
+      <SectionDivider variant="particles" className="opacity-50" />
 
       {/* About Preview */}
       <section className="py-16">


### PR DESCRIPTION
This PR introduces a set of decorative SVG section dividers to enhance the visual rhythm and aesthetic of the portfolio website. 

The new `SectionDivider` component supports five variants:
- **Waves**: A subtle waving line.
- **Lines**: A set of three horizontal lines with varying widths and opacities.
- **Dots**: A series of dots with varying sizes and opacities.
- **Network**: A connected node-and-line representation.
- **Particles**: A scattered set of dots of different sizes.

These dividers have been integrated into the following pages:
- **HomePage**: Separating the Hero, Featured Projects, Recent Posts, and About sections.
- **AboutPage**: Replacing the standard `Separator` between all major bio, experience, and education sections with varied variants.
- **BlogPage**: Separating the page header from the post list.

All SVGs are decorative (`aria-hidden="true"`) and use `currentColor` to support the site's dark theme. Visual verification was performed using Playwright screenshots.

Fixes #165

---
*PR created automatically by Jules for task [14413251759316970557](https://jules.google.com/task/14413251759316970557) started by @seanbearden*