### PR TITLE
ci: restore auto-label-issues using JULES_LABEL_PAT

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,28 @@
+name: Auto-label new issues
+
+# Apply the `jules` label to every newly opened issue. Uses JULES_LABEL_PAT
+# (a user PAT with Issues: write) instead of GITHUB_TOKEN — Jules treats
+# labels applied by github-actions[bot] as unauthorized, so we route the
+# label-application through the user identity. See PR #190 for the original
+# decision to delete this workflow, and the follow-up that restored it.
+#
+# To opt out for a specific issue (e.g., review-only or self-task), remove
+# the `jules` label after creation; Jules won't re-add it.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add jules label
+        env:
+          GH_TOKEN: ${{ secrets.JULES_LABEL_PAT }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: gh issue edit "$ISSUE" --add-label "jules" --repo "$REPO"


### PR DESCRIPTION
## Summary

Reverses the deletion of `auto-label-issues.yml` in #190, but uses `secrets.JULES_LABEL_PAT` (the user PAT with Issues: write) instead of `GITHUB_TOKEN` so the label-application traces to the repo owner — which is what Jules's actor-auth check requires.

## Why restore

Auto-labeling every new issue is the desired UX after all — eliminates a manual step and keeps the trigger surface predictable. The original deletion was a partial response to the bot-actor problem; using the PAT solves both:

- ✅ Jules picks up the issue (label applied as @seanbearden)
- ✅ User doesn't have to remember to label every issue
- ✅ Opt-out path remains (remove the label on issues that should be review-only / self-tasks)

## Behaviour

| Scenario | Before #190 | After #190 (current main) | After this PR |
|---|---|---|---|
| Human creates issue | auto-label, applied as bot, Jules ❌ | no auto-label | auto-label, applied as user, Jules ✅ |
| ZAP creates issue | n/a (separate workflow) | inline-labeled by PAT | inline-labeled by PAT (unchanged) |

## Why not a GitHub App instead

Considered. Skipped because Jules's empirically observed authorization model is actor-based on the user identity. A GitHub App would install as `<app-name>[bot]` — there's no documented way for Jules to trust an arbitrary app's identity, and migrating risks regressing the trigger that just started working. PAT remains fit-for-purpose. Revisit if/when we accumulate non-Jules automation that doesn't have actor restrictions.

## Test plan

- [ ] Merge
- [ ] Create a test issue (`gh issue create --title "test: jules trigger" --body "noop"`)
- [ ] Verify in the events log: `jules` label applied by `seanbearden`, not `github-actions[bot]`
- [ ] Confirm Jules picks it up
- [ ] Close the test issue

Per AGENTS.md skip list, no changeset (workflow-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)