### PR TITLE
fix: rename cloud-sql-connector → cloud-sql-python-connector

### DIFF
--- a/scripts/requirements-ingest.txt
+++ b/scripts/requirements-ingest.txt
@@ -1,6 +1,11 @@
 psycopg2-binary==2.9.9
 google-cloud-aiplatform==1.48.0
-google-cloud-sql-connector[psycopg2]==1.7.1
+# The Cloud SQL connector package was renamed on PyPI:
+# `google-cloud-sql-connector` (legacy, no longer published) →
+# `cloud-sql-python-connector`. The Python import path
+# `google.cloud.sql.connector` is the same in both, so no code changes
+# in ingest_portfolio.py / query_test.py.
+cloud-sql-python-connector[psycopg2]==1.20.2
 python-frontmatter==1.1.0
 langchain-text-splitters==0.0.1
 pgvector==0.2.5


### PR DESCRIPTION
## Summary

Fix CI failure across multiple in-flight PRs (#187, possibly others touching `scripts/requirements-ingest.txt`):

\`\`\`
ERROR: No matching distribution found for google-cloud-sql-connector==1.7.1
\`\`\`

The Google-published Cloud SQL Python connector was renamed on PyPI: \`google-cloud-sql-connector\` is no longer published. Current package is **\`cloud-sql-python-connector\`** (latest 1.20.2).

## What changes

- \`scripts/requirements-ingest.txt\`: \`google-cloud-sql-connector[psycopg2]==1.7.1\` → \`cloud-sql-python-connector[psycopg2]==1.20.2\`
- Comment block above the line documenting the rename so it's not re-introduced by future automation.

## What does NOT need to change

The Python import path is the same in both packages:
\`\`\`python
from google.cloud.sql.connector import Connector
\`\`\`

So \`scripts/ingest_portfolio.py\` and \`scripts/query_test.py\` need no changes.

## Verification

\`\`\`bash
$ pip index versions cloud-sql-python-connector
cloud-sql-python-connector (1.20.2)
Available versions: 1.20.2, 1.20.1, ..., 0.1.0

$ pip index versions google-cloud-sql-connector
ERROR: No matching distribution found for google-cloud-sql-connector
\`\`\`

## Why a separate PR

Multiple in-flight PRs (e.g. #181's reindex workflow + #187's eval suite) hit this same CI failure independently. Fixing it on main once unblocks all of them after they rebase.

Per AGENTS.md skip list, no changeset (scripts only, not in shipped frontend bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)